### PR TITLE
chore: Use golangci-lint v1.20

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,7 @@
 
 run:
   concurrency: 4
-  deadline: 5m
+  timeout: 5m
   issues-exit-code: 1
   tests: true
   build-tags: ["testing"]

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,7 @@ license:
 	@scripts/check_license.sh
 
 lint:
-# TODO: Disable linting for now since the linter panics with "out of memory". Re-enable once golangcli-lint 1.20.0 is released
-# 	@scripts/check_lint.sh
+	@scripts/check_lint.sh
 
 unit-test: checks
 	@scripts/unit.sh

--- a/scripts/check_lint.sh
+++ b/scripts/check_lint.sh
@@ -11,4 +11,4 @@ echo "Running $0"
 
 DOCKER_CMD=docker
 
-${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace golangci/golangci-lint golangci-lint run
+${DOCKER_CMD} run --rm -e GOPROXY=${GOPROXY} -v $(pwd):/opt/workspace -w /opt/workspace golangci/golangci-lint:v1.20 golangci-lint run


### PR DESCRIPTION
Re-enabled check_lint with golanci-lint v1.20 which uses much less memory.

closes #62

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>