### PR TITLE
test: BDD test for document monitor and recovery

### DIFF
--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -8,8 +8,9 @@
 @did-sidetree
 Feature:
   Background: Setup
-    Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=1h
-    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=3, maxPeerCount=3, and timeToLive=1h
+    Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
+    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
+    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=1, and timeToLive=60m
 
     Given the channel "mychannel" is created and all peers have joined
 
@@ -18,7 +19,7 @@ Feature:
     And chaincode "sidetreetxn_cc" is warmed up on all peers on the "mychannel" channel
 
     And "system" chaincode "document_cc" is installed from path "github.com/trustbloc/sidetree-fabric/cmd/chaincode/doc" to all peers
-    And "system" chaincode "document_cc" is instantiated from path "github.com/trustbloc/sidetree-fabric/cmd/chaincode/doc" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "docs-mychannel"
+    And "system" chaincode "document_cc" is instantiated from path "github.com/trustbloc/sidetree-fabric/cmd/chaincode/doc" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "docs-mychannel,meta_data_coll"
     And chaincode "document_cc" is warmed up on all peers on the "mychannel" channel
 
   @create_did_doc

--- a/test/bddtests/features/sidetreetxn.feature
+++ b/test/bddtests/features/sidetreetxn.feature
@@ -11,8 +11,9 @@ Feature:
     @sidetree_1
     Scenario: Sidetree Txn Test
 
-        Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=6000s
-        Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=3, maxPeerCount=3, and timeToLive=6000s
+        Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
+        Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
+        Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=1, and timeToLive=60m
 
         Given the channel "mychannel" is created and all peers have joined
 
@@ -21,7 +22,7 @@ Feature:
         And chaincode "sidetreetxn_cc" is warmed up on all peers on the "mychannel" channel
 
         And "system" chaincode "document_cc" is installed from path "github.com/trustbloc/sidetree-fabric/cmd/chaincode/doc" to all peers
-        And "system" chaincode "document_cc" is instantiated from path "github.com/trustbloc/sidetree-fabric/cmd/chaincode/doc" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "docs-mychannel"
+        And "system" chaincode "document_cc" is instantiated from path "github.com/trustbloc/sidetree-fabric/cmd/chaincode/doc" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "docs-mychannel,meta_data_coll"
         And chaincode "document_cc" is warmed up on all peers on the "mychannel" channel
 
         # sidetree content test
@@ -32,11 +33,21 @@ Feature:
         When client creates document with ID "did:sidetree:abc" using "document_cc" on the "mychannel" channel
         Then client verifies that query by index ID "did:sidetree:abc" from "document_cc" will return "1" versions of the document on the "mychannel" channel
 
+        # Bring down peer1.org1 so that it doesn't get the documents via Gossip broadcast
+        Given container "peer1.org1.example.com" is paused
+        # Wait a while so that Discovery will give up on this peer and remove it from the list of 'alive' peers
+        And we wait 120 seconds
+
         # write sidetree transaction
         When client writes operations batch file and anchor file for ID "did:sidetree:123abc" using "sidetreetxn_cc" on the "mychannel" channel
+        # Wait a while before unpausing peer1.org1 so that Gossip gives up trying to push the documents to the peer
+        And we wait 65 seconds
+        Then container "peer1.org1.example.com" is unpaused
+        # Wait a while to give peer1.org1 a chance to commit all blocks and get back in Discovery's list of 'alive' peers
+        And we wait 30 seconds
 
-        # batch writer needs some time to cut batch
-        Then we wait 5 seconds
-
-        Then client verifies that query by index ID "did:sidetree:123abc" from "document_cc" will return "2" versions of the document on the "mychannel" channel
-
+        # Make sure that all peers have the document, including peer1.org1 which just came up
+        Then client verifies that query by index ID "did:sidetree:123abc" from "document_cc" will return "2" versions of the document on the "mychannel" channel on peers "peer0.org1.example.com"
+        And client verifies that query by index ID "did:sidetree:123abc" from "document_cc" will return "2" versions of the document on the "mychannel" channel on peers "peer0.org2.example.com"
+        And client verifies that query by index ID "did:sidetree:123abc" from "document_cc" will return "2" versions of the document on the "mychannel" channel on peers "peer1.org2.example.com"
+        And client verifies that query by index ID "did:sidetree:123abc" from "document_cc" will return "2" versions of the document on the "mychannel" channel on peers "peer1.org1.example.com"

--- a/test/bddtests/features/step_definitions/sidetree_steps.js
+++ b/test/bddtests/features/step_definitions/sidetree_steps.js
@@ -26,6 +26,9 @@ var myStepDefinitionsWrapper = function () {
     this.Then(/^client verifies that query by index ID "([^"]*)" from "([^"]*)" will return "([^"]*)" versions of the document on the "([^"]*)" channel$/, function (arg1, arg2, arg3, arg4, callback) {
         callback.pending();
     });
+    this.Then(/^client verifies that query by index ID "([^"]*)" from "([^"]*)" will return "([^"]*)" versions of the document on the "([^"]*)" channel on peers "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, callback) {
+        callback.pending();
+    });
     this.When(/^client writes operations batch file and anchor file for ID "([^"]*)" using "([^"]*)" on the "([^"]*)" channel$/, function (arg1, arg2, arg3, callback) {
         callback.pending();
     });

--- a/test/bddtests/fixtures/config/client/config.yaml
+++ b/test/bddtests/fixtures/config/client/config.yaml
@@ -21,7 +21,7 @@ client:
   # Global configuration for peer, event service and orderer timeouts
   peer:
     timeout:
-      connection: 10s
+      connection: 5s
       response: 20s
       discovery:
         # Expiry period for discovery service greylist filter
@@ -43,7 +43,7 @@ client:
       execute: 120s
       resmgmt: 120s
     cache:
-      connectionIdle: 30s
+      connectionIdle: 5s
       eventServiceIdle: 2m
       channelConfig: 60s
       channelMembership: 30s
@@ -165,12 +165,8 @@ organizations:
 # and event listener registration.
 #
 peers:
-  peer0.org1.example.com:
-    # this URL is used to send endorsement and query requests
-    url: peer0.org1.example.com:7051
-
+  _default:
     grpcOptions:
-      ssl-target-name-override: peer0.org1.example.com
       grpc.http2.keepalive_time: 15
       #     These parameters should be set in coordination with the keepalive policy on the server,
       #     as incompatible settings can result in closing of connection.
@@ -181,6 +177,13 @@ peers:
       fail-fast: true
       #will be taken into consideration if address has no protocol defined and secured connection fails
       allow-insecure: false
+
+  peer0.org1.example.com:
+    # this URL is used to send endorsement and query requests
+    url: peer0.org1.example.com:7051
+
+    grpcOptions:
+      ssl-target-name-override: peer0.org1.example.com
 
     tlsCACerts:
       # Certificate location absolute path
@@ -192,16 +195,6 @@ peers:
 
     grpcOptions:
       ssl-target-name-override: peer1.org1.example.com
-      grpc.http2.keepalive_time: 15
-      #     These parameters should be set in coordination with the keepalive policy on the server,
-      #     as incompatible settings can result in closing of connection.
-      #     When duration of the 'keep-alive-time' is set to 0 or less the keep alive client parameters are disabled
-      keep-alive-time: 0s
-      keep-alive-timeout: 20s
-      keep-alive-permit: false
-      fail-fast: true
-      #will be taken into consideration if address has no protocol defined and secured connection fails
-      allow-insecure: false
 
     tlsCACerts:
       # Certificate location absolute path
@@ -222,15 +215,13 @@ orderers:
       keep-alive-time: 0s
       keep-alive-timeout: 20s
       keep-alive-permit: false
-      fail-fast: false
+      fail-fast: true
       #will be taken into consideration if address has no protocol defined and secured connection fails
       allow-insecure: false
 
     tlsCACerts:
       # Certificate location absolute path
       path: /etc/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem
-
-
 
 entityMatchers:
 

--- a/test/bddtests/fixtures/config/sdk-client/config.yaml
+++ b/test/bddtests/fixtures/config/sdk-client/config.yaml
@@ -230,7 +230,7 @@ orderers:
       keep-alive-time: 0s
       keep-alive-timeout: 20s
       keep-alive-permit: false
-      fail-fast: false
+      fail-fast: true
       #will be taken into consideration if address has no protocol defined and secured connection fails
       allow-insecure: false
 
@@ -295,22 +295,25 @@ organizations:
 # and event listener registration.
 #
 peers:
-  peer0.org1.example.com:
-    # this URL is used to send endorsement and query requests
-    url: localhost:7051
-
+  _default:
     grpcOptions:
-      ssl-target-name-override: peer0.org1.example.com
       grpc.http2.keepalive_time: 15
-#     These parameters should be set in coordination with the keepalive policy on the server,
-#     as incompatible settings can result in closing of connection.
-#     When duration of the 'keep-alive-time' is set to 0 or less the keep alive client parameters are disabled
+      #     These parameters should be set in coordination with the keepalive policy on the server,
+      #     as incompatible settings can result in closing of connection.
+      #     When duration of the 'keep-alive-time' is set to 0 or less the keep alive client parameters are disabled
       keep-alive-time: 0s
       keep-alive-timeout: 20s
       keep-alive-permit: false
       fail-fast: true
       #will be taken into consideration if address has no protocol defined and secured connection fails
       allow-insecure: false
+
+  peer0.org1.example.com:
+    # this URL is used to send endorsement and query requests
+    url: localhost:7051
+
+    grpcOptions:
+      ssl-target-name-override: peer0.org1.example.com
 
     tlsCACerts:
       # Certificate location absolute path
@@ -322,16 +325,6 @@ peers:
 
     grpcOptions:
       ssl-target-name-override: peer1.org1.example.com
-      grpc.http2.keepalive_time: 15
-      #     These parameters should be set in coordination with the keepalive policy on the server,
-      #     as incompatible settings can result in closing of connection.
-      #     When duration of the 'keep-alive-time' is set to 0 or less the keep alive client parameters are disabled
-      keep-alive-time: 0s
-      keep-alive-timeout: 20s
-      keep-alive-permit: false
-      fail-fast: true
-      #will be taken into consideration if address has no protocol defined and secured connection fails
-      allow-insecure: false
 
     tlsCACerts:
       # Certificate location absolute path
@@ -343,16 +336,6 @@ peers:
 
     grpcOptions:
       ssl-target-name-override: peer0.org2.example.com
-      grpc.http2.keepalive_time: 15
-      #     These parameters should be set in coordination with the keepalive policy on the server,
-      #     as incompatible settings can result in closing of connection.
-      #     When duration of the 'keep-alive-time' is set to 0 or less the keep alive client parameters are disabled
-      keep-alive-time: 0s
-      keep-alive-timeout: 20s
-      keep-alive-permit: false
-      fail-fast: true
-      #will be taken into consideration if address has no protocol defined and secured connection fails
-      allow-insecure: false
 
     tlsCACerts:
       # Certificate location absolute path
@@ -364,23 +347,12 @@ peers:
 
     grpcOptions:
       ssl-target-name-override: peer1.org2.example.com
-      grpc.http2.keepalive_time: 15
-      #     These parameters should be set in coordination with the keepalive policy on the server,
-      #     as incompatible settings can result in closing of connection.
-      #     When duration of the 'keep-alive-time' is set to 0 or less the keep alive client parameters are disabled
-      keep-alive-time: 0s
-      keep-alive-timeout: 20s
-      keep-alive-permit: false
-      fail-fast: true
-      #will be taken into consideration if address has no protocol defined and secured connection fails
-      allow-insecure: false
 
     tlsCACerts:
       # Certificate location absolute path
       path: ${GOPATH}/src/github.com/trustbloc/sidetree-fabric/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
 
 entityMatchers:
-
   peer:
     - pattern: peer0.org1.example.com:(\d+)
       urlSubstitutionExp: localhost:7051

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       # metrics config
       - CORE_METRICS_PROVIDER=prometheus
       - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      - CORE_LEDGER_ROLES=endorser,committer,validator,observer
+      - CORE_LEDGER_ROLES=endorser,committer,validator,sidetree,observer
       # channels to observe for Sidetree transaction
       - CORE_LEDGER_SIDETREE_OBSERVER_CHANNELS=mychannel
       # # the following setting starts chaincode containers on the same
@@ -121,6 +121,7 @@ services:
       # metrics config
       - CORE_METRICS_PROVIDER=prometheus
       - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
+      - CORE_LEDGER_ROLES=endorser,committer,validator,sidetree
       # channels to observe for Sidetree transaction
       - CORE_LEDGER_SIDETREE_OBSERVER_CHANNELS=mychannel
       # # the following setting starts chaincode containers on the same
@@ -176,6 +177,7 @@ services:
       # metrics config
       - CORE_METRICS_PROVIDER=prometheus
       - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
+      - CORE_LEDGER_ROLES=endorser,committer,validator,sidetree
       # channels to observe for Sidetree transaction
       - CORE_LEDGER_SIDETREE_OBSERVER_CHANNELS=mychannel
       # # the following setting starts chaincode containers on the same
@@ -230,6 +232,7 @@ services:
       # metrics config
       - CORE_METRICS_PROVIDER=prometheus
       - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
+      - CORE_LEDGER_ROLES=endorser,committer,validator,sidetree
       # channels to observe for Sidetree transaction
       - CORE_LEDGER_SIDETREE_OBSERVER_CHANNELS=mychannel
       # # the following setting starts chaincode containers on the same


### PR DESCRIPTION
Added a BDD test to demonstrate recovery of document operations in the local DCAS store on a peer that was down during the time that the data was published.

closes #69

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>