### PR TITLE
chore: Fix for fabric-cli-ext build on Mac

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ FABRIC_PEER_EXT_IMAGE   ?= trustbloc/fabric-peer
 FABRIC_PEER_EXT_VERSION ?= 0.1.1
 FABRIC_PEER_EXT_TAG     ?= $(ARCH)-$(FABRIC_PEER_EXT_VERSION)
 
-FABRIC_CLI_EXT_VERSION ?= 0.1.1
+export FABRIC_CLI_EXT_VERSION ?= 3fd66894726c1afcd904413dcfa3b4d586ea6c92
 
 # Namespace for the blocnode image
 DOCKER_OUTPUT_NS     ?= trustbloc


### PR DESCRIPTION
Point to the latest fabric-cli-ext which works with both Mac and Linux.

closes #116

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>