### PR TITLE
fix: Monitor will retry only transient errors

### DIFF
--- a/cmd/peer/go.mod
+++ b/cmd/peer/go.mod
@@ -13,9 +13,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.2
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200225164210-a4c6d40d6df2
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.2
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0
 
 replace github.com/trustbloc/sidetree-fabric => ../..
 

--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -340,10 +340,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.2 h1:xEbseWYXJ1QWT0jGIXVyrFXgduO2jRTFZWNLr8nMMY0=
 github.com/trustbloc/fabric-mod v0.1.2/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.2 h1:HnrsqZFGiIqovxWKM5NK9ElOwfMJTYgV73wAysgAnrY=
-github.com/trustbloc/fabric-peer-ext v0.1.2/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200225164210-a4c6d40d6df2 h1:PNplbo6YrNdEnJ+vBCBT6o5EnLMh81gacUr8YekbUGk=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200225164210-a4c6d40d6df2/go.mod h1:x0at26YrCn4zhl15B2dPujacNRVc6Hi0VwK38jcSsZc=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0 h1:diBO03DH5ZXqoJehzGH+Vvx2X5z/1/CgZFH1lBvsl2A=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0 h1:DeboASCeoPwU4hl25QP5hbQ6QeJDiwyFkzeQkBXIcA0=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0/go.mod h1:x0at26YrCn4zhl15B2dPujacNRVc6Hi0VwK38jcSsZc=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200228183402-1d2881040159 h1:sxC//7eJ7vuT+GscqAGT1jqfPxJEEIwTCPlJiMSKxNE=

--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.2
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200225164210-a4c6d40d6df2
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.2
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2
 

--- a/go.sum
+++ b/go.sum
@@ -352,10 +352,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.2 h1:xEbseWYXJ1QWT0jGIXVyrFXgduO2jRTFZWNLr8nMMY0=
 github.com/trustbloc/fabric-mod v0.1.2/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.2 h1:HnrsqZFGiIqovxWKM5NK9ElOwfMJTYgV73wAysgAnrY=
-github.com/trustbloc/fabric-peer-ext v0.1.2/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200225164210-a4c6d40d6df2 h1:PNplbo6YrNdEnJ+vBCBT6o5EnLMh81gacUr8YekbUGk=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200225164210-a4c6d40d6df2/go.mod h1:x0at26YrCn4zhl15B2dPujacNRVc6Hi0VwK38jcSsZc=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0 h1:diBO03DH5ZXqoJehzGH+Vvx2X5z/1/CgZFH1lBvsl2A=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0 h1:DeboASCeoPwU4hl25QP5hbQ6QeJDiwyFkzeQkBXIcA0=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0/go.mod h1:x0at26YrCn4zhl15B2dPujacNRVc6Hi0VwK38jcSsZc=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200228183402-1d2881040159 h1:sxC//7eJ7vuT+GscqAGT1jqfPxJEEIwTCPlJiMSKxNE=

--- a/pkg/observer/monitor/dcasreader_test.go
+++ b/pkg/observer/monitor/dcasreader_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package monitor
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -22,11 +23,44 @@ func TestSidetreeDCASReader_Read(t *testing.T) {
 	r := NewSidetreeDCASReader(channel1, dcasClientProvider)
 	require.NotNil(t, r)
 
-	expectedValue := []byte("some value")
-	key, err := dcasClient.Put(common.SidetreeNs, common.SidetreeColl, expectedValue)
-	require.NoError(t, err)
+	t.Run("Found", func(t *testing.T) {
+		expectedValue := []byte("some value")
+		key, err := dcasClient.Put(common.SidetreeNs, common.SidetreeColl, expectedValue)
+		require.NoError(t, err)
 
-	value, err := r.Read(key)
-	require.NoError(t, err)
-	require.Equal(t, expectedValue, value)
+		value, err := r.Read(key)
+		require.NoError(t, err)
+		require.Equal(t, expectedValue, value)
+	})
+
+	t.Run("Not found", func(t *testing.T) {
+		value, err := r.Read("some key")
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "content not found for key")
+		require.Nil(t, value)
+
+		merr, ok := err.(monitorError)
+		require.True(t, ok)
+		require.False(t, merr.Transient())
+	})
+}
+
+func TestSidetreeDCASReader_ReadError(t *testing.T) {
+	dcasClient := obmocks.NewMockDCASClient()
+
+	dcasClientProvider := &stmocks.DCASClientProvider{}
+	dcasClientProvider.ForChannelReturns(dcasClient, nil)
+	r := NewSidetreeDCASReader(channel1, dcasClientProvider)
+	require.NotNil(t, r)
+
+	errExpected := errors.New("injected Put error")
+	dcasClient.GetErr = errExpected
+
+	value, err := r.Read("some-key")
+	require.EqualError(t, err, errExpected.Error())
+	require.Nil(t, value)
+
+	merr, ok := err.(monitorError)
+	require.True(t, ok)
+	require.True(t, merr.Transient())
 }

--- a/pkg/observer/monitor/monitorerr.go
+++ b/pkg/observer/monitor/monitorerr.go
@@ -1,0 +1,27 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package monitor
+
+type monitorError struct {
+	cause     error
+	transient bool
+}
+
+func newMonitorError(cause error, transient bool) monitorError {
+	return monitorError{
+		cause:     cause,
+		transient: transient,
+	}
+}
+
+func (e monitorError) Error() string {
+	return e.cause.Error()
+}
+
+func (e monitorError) Transient() bool {
+	return e.transient
+}

--- a/pkg/observer/monitor/monitorerr_test.go
+++ b/pkg/observer/monitor/monitorerr_test.go
@@ -1,0 +1,22 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package monitor
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMonitorError(t *testing.T) {
+	err := errors.New("cause of error")
+	merr := newMonitorError(err, true)
+	require.NotNil(t, merr)
+	require.Equal(t, err.Error(), merr.Error())
+	require.True(t, merr.Transient())
+}

--- a/pkg/observer/monitor/operationstore_test.go
+++ b/pkg/observer/monitor/operationstore_test.go
@@ -60,12 +60,24 @@ func TestOperationStore_PutError(t *testing.T) {
 	t.Run("DCAS get error", func(t *testing.T) {
 		dcasClient.WithGetError(errors.New("injected DCAS error"))
 		defer dcasClient.WithGetError(nil)
-		require.Error(t, s.Put([]*batch.Operation{op1}))
+
+		err := s.Put([]*batch.Operation{op1})
+		require.Error(t, err)
+
+		merr, ok := err.(monitorError)
+		require.True(t, ok)
+		require.True(t, merr.Transient())
 	})
 
 	t.Run("DCAS put error", func(t *testing.T) {
 		dcasClient.WithPutError(errors.New("injected DCAS error"))
 		defer dcasClient.WithPutError(nil)
-		require.Error(t, s.Put([]*batch.Operation{op1}))
+
+		err := s.Put([]*batch.Operation{op1})
+		require.Error(t, err)
+
+		merr, ok := err.(monitorError)
+		require.True(t, ok)
+		require.True(t, merr.Transient())
 	})
 }

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -8,9 +8,9 @@
 @did-sidetree
 Feature:
   Background: Setup
-    Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
-    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
-    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=60m
+    Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
+    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
+    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
     And the channel "yourchannel" is created and all peers have joined

--- a/test/bddtests/features/sidetreetxn.feature
+++ b/test/bddtests/features/sidetreetxn.feature
@@ -8,9 +8,9 @@
 @sidetreetxn
 Feature:
   Background: Setup
-    Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
-    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
-    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=60m
+    Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
+    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
+    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
 


### PR DESCRIPTION
The Monitor now differentiates between persistent errors and transient errors. A transient error is temporary and retries on the request should eventually succeed. A persistent error will always fail.

closes #140

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>