### PR TITLE
feat: Change structure of file index document

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
 	github.com/btcsuite/btcutil v0.0.0-20170419141449-a5ecb5d9547a
 	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/gorilla/mux v1.7.3
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/pkg/filehandler/model.go
+++ b/pkg/filehandler/model.go
@@ -11,3 +11,16 @@ type File struct {
 	ContentType string `json:"contentType"`
 	Content     []byte `json:"content"`
 }
+
+// FileIndexDoc contains a file index document
+type FileIndexDoc struct {
+	ID           string    `json:"id"`
+	UniqueSuffix string    `json:"didUniqueSuffix"`
+	FileIndex    FileIndex `json:"fileIndex"`
+}
+
+// FileIndex contains the mappings of file name to ID
+type FileIndex struct {
+	BasePath string            `json:"basePath"`
+	Mappings map[string]string `json:"mappings"`
+}

--- a/pkg/filehandler/validator.go
+++ b/pkg/filehandler/validator.go
@@ -1,0 +1,143 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package filehandler
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/trustbloc/sidetree-core-go/pkg/dochandler/docvalidator"
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+)
+
+const (
+	jsonPatchBasePath = "/fileIndex/mappings/"
+)
+
+// Validator validates the file index Sidetree document
+type Validator struct {
+	*docvalidator.Validator
+}
+
+// NewValidator returns a new file index document validator
+func NewValidator(store docvalidator.OperationStoreClient) *Validator {
+	return &Validator{
+		Validator: docvalidator.New(store),
+	}
+}
+
+// IsValidOriginalDocument verifies that the given payload is a valid Sidetree specific document that can be accepted by the Sidetree create operation.
+func (v *Validator) IsValidOriginalDocument(payload []byte) error {
+	logger.Debugf("Validating file handler original document %s", payload)
+
+	if err := v.Validator.IsValidOriginalDocument(payload); err != nil {
+		return err
+	}
+
+	fileIndexDoc := &FileIndexDoc{}
+	err := jsonUnmarshal(payload, fileIndexDoc)
+	if err != nil {
+		return err
+	}
+
+	if fileIndexDoc.FileIndex.BasePath == "" {
+		return errors.New("missing base path")
+	}
+
+	for name, id := range fileIndexDoc.FileIndex.Mappings {
+		if name == "" {
+			return errors.New("missing file name in mapping")
+		}
+		if id == "" {
+			return errors.Errorf("missing ID for file name [%s]", name)
+		}
+	}
+
+	return nil
+}
+
+// IsValidPayload verifies that the given payload is a valid Sidetree specific payload
+// that can be accepted by the Sidetree update operations
+func (v *Validator) IsValidPayload(payload []byte) error {
+	logger.Debugf("Validating file handler payload %s", payload)
+
+	if err := v.Validator.IsValidPayload(payload); err != nil {
+		return err
+	}
+
+	uniqueSuffix, op, err := unmarshalUpdateOperation(payload)
+	if err != nil {
+		return err
+	}
+
+	for _, patch := range op.DocumentPatch {
+		if err := validatePatch(patch); err != nil {
+			logger.Infof("Invalid JSON patch operation for [%s]: %s", uniqueSuffix, err)
+			return errors.WithMessage(err, "invalid JSON patch")
+		}
+	}
+
+	return nil
+}
+
+// TransformDocument takes internal representation of document and transforms it to required representation
+func (v *Validator) TransformDocument(document document.Document) (document.Document, error) {
+	return document, nil
+}
+
+type patchOperation = map[string]*json.RawMessage
+
+func validatePatch(op patchOperation) error {
+	pathMsg, ok := op["path"]
+	if !ok {
+		return errors.New("path not found")
+	}
+
+	var path string
+	if err := jsonUnmarshal(*pathMsg, &path); err != nil {
+		return errors.New("invalid path")
+	}
+
+	logger.Debugf("Got path from JSON patch: [%s]", path)
+
+	if !strings.HasPrefix(path, jsonPatchBasePath) {
+		return errors.New("only the mappings section of a file index document may be modified")
+	}
+
+	return nil
+}
+
+var unmarshalUpdateOperation = func(reqPayload []byte) (string, *model.UpdateOperationData, error) {
+	req := &model.UpdateRequest{}
+	if err := json.Unmarshal(reqPayload, req); err != nil {
+		logger.Infof("Error unmarshalling update request: %s", err)
+		return "", nil, errors.New("invalid update request")
+	}
+
+	opDataBytes, err := docutil.DecodeString(req.OperationData)
+	if err != nil {
+		logger.Infof("Error decoding operation data for [%s]: %s", req.DidUniqueSuffix, err)
+		return req.DidUniqueSuffix, nil, errors.New("invalid operation data")
+	}
+
+	logger.Debugf("Validating operation data for [%s]: %s", req.DidUniqueSuffix, opDataBytes)
+
+	op := &model.UpdateOperationData{}
+	if err := json.Unmarshal(opDataBytes, op); err != nil {
+		logger.Infof("Error unmarshalling operation data for [%s]: %s", req.DidUniqueSuffix, err)
+		return req.DidUniqueSuffix, nil, errors.New("invalid operation data")
+	}
+
+	return req.DidUniqueSuffix, op, nil
+}
+
+var jsonUnmarshal = func(bytes []byte, obj interface{}) error {
+	return json.Unmarshal(bytes, obj)
+}

--- a/pkg/filehandler/validator_test.go
+++ b/pkg/filehandler/validator_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package filehandler
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	jsonpatch "github.com/evanphx/json-patch"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+	"github.com/trustbloc/sidetree-fabric/pkg/observer/mocks"
+)
+
+const sha2_256 = 18
+
+func TestDocumentValidator_IsValidOriginalDocument(t *testing.T) {
+	v := NewValidator(&mocks.OperationStoreClient{})
+	require.NotNil(t, v)
+
+	t.Run("Invalid document", func(t *testing.T) {
+		doc := &FileIndexDoc{
+			ID: "file:idx:1234",
+		}
+		docBytes, err := json.Marshal(doc)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidOriginalDocument(docBytes), "document must NOT have the id property")
+	})
+
+	t.Run("No basePath", func(t *testing.T) {
+		doc := &FileIndexDoc{
+			UniqueSuffix: "1234",
+		}
+		docBytes, err := json.Marshal(doc)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidOriginalDocument(docBytes), "missing base path")
+	})
+
+	t.Run("No file name", func(t *testing.T) {
+		doc := &FileIndexDoc{
+			UniqueSuffix: "1234",
+			FileIndex: FileIndex{
+				BasePath: "/schema",
+				Mappings: map[string]string{
+					"": "",
+				},
+			},
+		}
+		docBytes, err := json.Marshal(doc)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidOriginalDocument(docBytes), "missing file name in mapping")
+	})
+
+	t.Run("No file ID", func(t *testing.T) {
+		doc := &FileIndexDoc{
+			UniqueSuffix: "1234",
+			FileIndex: FileIndex{
+				BasePath: "/schema",
+				Mappings: map[string]string{
+					"schema1.json": "",
+				},
+			},
+		}
+		docBytes, err := json.Marshal(doc)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidOriginalDocument(docBytes), "missing ID for file name [schema1.json]")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		doc := &FileIndexDoc{
+			UniqueSuffix: "1234",
+			FileIndex: FileIndex{
+				BasePath: "/schema",
+				Mappings: map[string]string{
+					"schema1.json": "1234567",
+				},
+			},
+		}
+		docBytes, err := json.Marshal(doc)
+		require.NoError(t, err)
+		require.NoError(t, v.IsValidOriginalDocument(docBytes))
+	})
+}
+
+func TestDocumentValidator_IsValidPayload(t *testing.T) {
+	s := &mocks.OperationStoreClient{}
+	s.GetReturns([]*batch.Operation{{}}, nil)
+
+	v := NewValidator(s)
+	require.NotNil(t, v)
+
+	t.Run("Invalid document", func(t *testing.T) {
+		require.EqualError(t, v.IsValidPayload([]byte("{}")), "missing unique suffix")
+	})
+
+	t.Run("Unmarshal operation error", func(t *testing.T) {
+		errExpected := errors.New("injected unmarshal op error")
+
+		restore := unmarshalUpdateOperation
+		unmarshalUpdateOperation = func([]byte) (s string, data *model.UpdateOperationData, err error) { return "", nil, errExpected }
+		defer func() { unmarshalUpdateOperation = restore }()
+
+		req, err := getUpdateRequest(`[{"op": "add", "path": "/fileIndex/mappings/schema1.json", "value": "ew3e23w3"}]`)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidPayload(req), errExpected.Error())
+	})
+
+	t.Run("No path in JSON patch", func(t *testing.T) {
+		req, err := getUpdateRequest(`[{"op": "replace"}]`)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidPayload(req), "invalid JSON patch: path not found")
+	})
+
+	t.Run("Unmarshal path error", func(t *testing.T) {
+		errExpected := errors.New("injected unmarshal JSON error")
+
+		restore := jsonUnmarshal
+		jsonUnmarshal = func(bytes []byte, obj interface{}) error { return errExpected }
+		defer func() { jsonUnmarshal = restore }()
+
+		req, err := getUpdateRequest(`[{"op": "add", "path": "/fileIndex/mappings/schema1.json", "value": "ew3e23w3"}]`)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidPayload(req), "invalid JSON patch: invalid path")
+	})
+
+	t.Run("Attempt to modify non-mappings section", func(t *testing.T) {
+		req, err := getUpdateRequest(`[{"op": "replace", "path": "/fileIndex", "value": "ew3e23w3"}]`)
+		require.NoError(t, err)
+		require.EqualError(t, v.IsValidPayload(req), "invalid JSON patch: only the mappings section of a file index document may be modified")
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		req, err := getUpdateRequest(`[{"op": "add", "path": "/fileIndex/mappings/schema1.json", "value": "ew3e23w3"}]`)
+		require.NoError(t, err)
+		require.NoError(t, v.IsValidPayload(req))
+	})
+}
+
+func TestDocumentValidator_TransformDocument(t *testing.T) {
+	v := NewValidator(&mocks.OperationStoreClient{})
+	require.NotNil(t, v)
+
+	doc := make(document.Document)
+	transformed, err := v.TransformDocument(doc)
+	require.NoError(t, err)
+	require.Equal(t, doc, transformed)
+}
+
+func TestUnmarshalUpdateOperation(t *testing.T) {
+	t.Run("Invalid payload", func(t *testing.T) {
+		suffix, op, err := unmarshalUpdateOperation([]byte("{"))
+		require.EqualError(t, err, "invalid update request")
+		require.Empty(t, suffix)
+		require.Nil(t, op)
+	})
+
+	t.Run("Invalid base64 encoding", func(t *testing.T) {
+		req := &model.UpdateRequest{
+			OperationData: `{"%sde3":"-+"}`,
+		}
+
+		reqBytes, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		suffix, op, err := unmarshalUpdateOperation(reqBytes)
+		require.EqualError(t, err, "invalid operation data")
+		require.Empty(t, suffix)
+		require.Nil(t, op)
+	})
+
+	t.Run("Invalid operation data", func(t *testing.T) {
+		encodedOp := docutil.EncodeToString([]byte("{"))
+
+		req := &model.UpdateRequest{
+			OperationData: encodedOp,
+		}
+
+		reqBytes, err := json.Marshal(req)
+		require.NoError(t, err)
+
+		suffix, op, err := unmarshalUpdateOperation(reqBytes)
+		require.EqualError(t, err, "invalid operation data")
+		require.Empty(t, suffix)
+		require.Nil(t, op)
+	})
+}
+
+func getUpdateRequest(patch string) ([]byte, error) {
+	jsonPatch, err := jsonpatch.DecodePatch([]byte(patch))
+	if err != nil {
+		return nil, err
+	}
+
+	return helper.NewUpdateRequest(
+		&helper.UpdateRequestInfo{
+			DidUniqueSuffix: "1234",
+			Patch:           jsonPatch,
+			MultihashCode:   sha2_256,
+		})
+}

--- a/pkg/peer/sidetreesvc/restsvc.go
+++ b/pkg/peer/sidetreesvc/restsvc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/diddochandler"
 	resthandler "github.com/trustbloc/sidetree-core-go/pkg/restapi/dochandler"
 
+	"github.com/trustbloc/sidetree-fabric/pkg/filehandler"
 	"github.com/trustbloc/sidetree-fabric/pkg/httpserver"
 	"github.com/trustbloc/sidetree-fabric/pkg/peer/config"
 	"github.com/trustbloc/sidetree-fabric/pkg/role"
@@ -154,7 +155,7 @@ var (
 	}
 
 	fileValidatorProvider = func(opStore docvalidator.OperationStoreClient) dochandler.DocumentValidator {
-		return docvalidator.New(opStore)
+		return filehandler.NewValidator(opStore)
 	}
 
 	fileResolveProvider = func(cfg config.Namespace, resolver resthandler.Resolver) common.HTTPHandler {

--- a/scripts/build_fabric_cli.sh
+++ b/scripts/build_fabric_cli.sh
@@ -21,7 +21,6 @@ make plugins
 
 cp ./.build/bin/fabric ../bin/
 cp -r ./.build/ledgerconfig/ ../ledgerconfig/
-cp -r ./.build/file/ ../file/
 
 cd ..
 rm -rf ./fabric-cli-ext

--- a/test/bddtests/features/step_definitions/filehandler_steps.js
+++ b/test/bddtests/features/step_definitions/filehandler_steps.js
@@ -9,10 +9,31 @@ var myStepDefinitionsWrapper = function () {
     this.When(/^client sends request to "([^"]*)" to create document "([^"]*)" in namespace "([^"]*)"$/, function (arg1, arg2, arg3, callback) {
         callback.pending();
     });
+    this.When(/^client sends request to "([^"]*)" to create document with content "([^"]*)" in namespace "([^"]*)"$/, function (arg1, arg2, arg3, callback) {
+        callback.pending();
+    });
+    this.When(/^client sends request to "([^"]*)" to update document "([^"]*)" with patch "([^"]*)"$/, function (arg1, arg2, arg3, callback) {
+        callback.pending();
+    });
     this.When(/^client sends request to "([^"]*)" to retrieve file$/, function (callback) {
         callback.pending();
     });
+    this.When(/^client sends request to "([^"]*)" to upload file "([^"]*)" with content type "([^"]*)"$/, function (callback) {
+        callback.pending();
+    });
+    this.When(/^the ID of the file is saved to variable "([^"]*)"/, function (callback) {
+        callback.pending();
+    });
+    this.When(/^the ID of the returned document is saved to variable "([^"]*)"/, function (callback) {
+        callback.pending();
+    });
+    this.When(/^the retrieved file contains "([^"]*)"/, function (callback) {
+        callback.pending();
+    });
     this.When(/^the response has status code (\d+) and error message "([^"]*)"/, function (callback) {
+        callback.pending();
+    });
+    this.When(/^variable "([^"]*)" is assigned the JSON patch '([^']*)'/, function (callback) {
         callback.pending();
     });
 };

--- a/test/bddtests/filehandler_steps.go
+++ b/test/bddtests/filehandler_steps.go
@@ -7,23 +7,132 @@ SPDX-License-Identifier: Apache-2.0
 package bddtests
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/cucumber/godog"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/pkg/errors"
+
 	"github.com/trustbloc/fabric-peer-test-common/bddtests"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/document"
+	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
+
 	"github.com/trustbloc/sidetree-fabric/test/bddtests/restclient"
 )
 
 // FileHandlerSteps
 type FileHandlerSteps struct {
-	resp *restclient.HttpResponse
+	encodedCreatePayload string
+	reqNamespace         string
+	resp                 *restclient.HttpResponse
+	bddContext           *bddtests.BDDContext
 }
 
 // NewFileHandlerSteps
-func NewFileHandlerSteps(_ *bddtests.BDDContext) *FileHandlerSteps {
-	return &FileHandlerSteps{}
+func NewFileHandlerSteps(context *bddtests.BDDContext) *FileHandlerSteps {
+	return &FileHandlerSteps{bddContext: context}
+}
+
+func (d *FileHandlerSteps) createDocument(url, content, namespace string) error {
+	resolved, err := bddtests.ResolveAllVars(content)
+	if err != nil {
+		return err
+	}
+
+	if len(resolved) != 1 {
+		return errors.Errorf("expecting 1 var but got %d", len(resolved))
+	}
+
+	content = resolved[0]
+
+	logger.Infof("Creating document at [%s] in namespace [%s] with content %s", url, namespace, content)
+
+	req, err := getCreateRequest(d.getOpaqueDocument(content))
+	if err != nil {
+		return err
+	}
+
+	d.encodedCreatePayload = docutil.EncodeToString(req)
+	d.reqNamespace = namespace
+
+	logger.Infof("Sending document to [%s]: %s", url, req)
+	d.resp, err = restclient.SendRequest(url, req)
+
+	logger.Infof("... got response from [%s]: %s", url, d.resp.Payload)
+
+	return err
+}
+
+func (d *FileHandlerSteps) updateDocument(url, docID, jsonPatch string) error {
+	logger.Infof("Updating document [%s] at [%s] with patch %s", docID, url, jsonPatch)
+
+	resolvedPatch, err := bddtests.ResolveAllVars(jsonPatch)
+	if err != nil {
+		return err
+	}
+
+	if len(resolvedPatch) != 1 {
+		return errors.Errorf("expecting 1 var but got %d", len(resolvedPatch))
+	}
+
+	jsonPatch = resolvedPatch[0]
+
+	resolvedDocID, err := bddtests.ResolveAllVars(docID)
+	if err != nil {
+		return err
+	}
+
+	if len(resolvedDocID) != 1 {
+		return errors.Errorf("expecting 1 var but got %d", len(resolvedDocID))
+	}
+
+	uniqueSuffix := getUniqueSuffix(resolvedDocID[0])
+
+	patch, err := jsonpatch.DecodePatch([]byte(jsonPatch))
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Updating document [%s] at [%s] with patch %s - %+v", docID, url, jsonPatch, patch)
+
+	req, err := d.getUpdateRequest(uniqueSuffix, patch)
+	if err != nil {
+		return err
+	}
+
+	logger.Infof("Sending update payload to [%s]: %s", url, req)
+
+	d.resp, err = restclient.SendRequest(url, []byte(req))
+
+	logger.Infof("... got response from [%s] - Status code: %d, Payload: %s", url, d.resp.StatusCode, d.resp.Payload)
+
+	return err
+}
+
+func (d *FileHandlerSteps) uploadFile(url, path, contentType string) error {
+	logger.Infof("Uploading file [%s] to [%s]", path, url)
+
+	fileBytes := getFile(path)
+
+	req := &UploadFile{
+		ContentType: contentType,
+		Content:     fileBytes,
+	}
+
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+
+	d.resp, err = restclient.SendRequest(url, reqBytes)
+	return err
 }
 
 func (d *FileHandlerSteps) resolveFile(url string) error {
@@ -36,6 +145,9 @@ func (d *FileHandlerSteps) resolveFile(url string) error {
 		if err != nil {
 			return err
 		}
+
+		bddtests.SetResponse(string(d.resp.Payload))
+
 		if d.resp.StatusCode == http.StatusNotFound {
 			logger.Infof("File not found: %s. Remaining attempts: %d", url, remainingAttempts)
 			remainingAttempts--
@@ -45,10 +157,27 @@ func (d *FileHandlerSteps) resolveFile(url string) error {
 			}
 		}
 
-		bddtests.SetResponse(string(d.resp.Payload))
-
 		return nil
 	}
+}
+
+func (d *FileHandlerSteps) checkErrorResp(errorMsg string) error {
+	if !strings.Contains(d.resp.ErrorMsg, errorMsg) {
+		return errors.Errorf("error resp %s doesn't contain %s", d.resp.ErrorMsg, errorMsg)
+	}
+	return nil
+}
+
+func (d *FileHandlerSteps) retrievedFileContains(msg string) error {
+	if d.resp.ErrorMsg != "" {
+		return errors.Errorf("error resp: [%s]", d.resp.ErrorMsg)
+	}
+
+	logger.Infof("check success resp %s contain %s", string(d.resp.Payload), msg)
+	if !strings.Contains(string(d.resp.Payload), msg) {
+		return errors.Errorf("success resp %s doesn't contain %s", d.resp.Payload, msg)
+	}
+	return nil
 }
 
 func (d *FileHandlerSteps) checkErrorResponse(statusCode int, msg string) error {
@@ -63,8 +192,116 @@ func (d *FileHandlerSteps) checkErrorResponse(statusCode int, msg string) error 
 	return nil
 }
 
+func (d *FileHandlerSteps) saveIDToVariable(varName string) error {
+	if d.resp.ErrorMsg != "" {
+		return errors.Errorf("error resp: [%s]", d.resp.ErrorMsg)
+	}
+
+	id := ""
+	if err := json.Unmarshal(d.resp.Payload, &id); err != nil {
+		return err
+	}
+
+	logger.Infof("Saving ID [%s] to variable [%s]", id, varName)
+
+	bddtests.SetVar(varName, id)
+	return nil
+}
+
+func (d *FileHandlerSteps) saveDocIDToVariable(varName string) error {
+	if d.resp.ErrorMsg != "" {
+		return errors.Errorf("error resp: [%s]", d.resp.ErrorMsg)
+	}
+
+	doc := document.Document{}
+	if err := json.Unmarshal(d.resp.Payload, &doc); err != nil {
+		return err
+	}
+
+	logger.Infof("Got doc %v", doc)
+	logger.Infof("Saving ID [%s] to variable [%s]", doc["id"], varName)
+
+	bddtests.SetVar(varName, doc["id"].(string))
+	return nil
+}
+
+func (d *FileHandlerSteps) setJSONPatchVar(varName, patch string) error {
+	var p []interface{}
+	err := json.Unmarshal([]byte(patch), &p)
+	if err != nil {
+		panic(err)
+	}
+
+	obj, err := bddtests.ResolveVars(p)
+	if err != nil {
+		panic(err)
+	}
+
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+
+	logger.Infof("Setting variable [%s] to JSON patch %s", varName, bytes)
+
+	bddtests.SetVar(varName, string(bytes))
+
+	return nil
+}
+
+func (d *FileHandlerSteps) getOpaqueDocument(content string) string {
+	doc, _ := document.FromBytes([]byte(content))
+	bytes, _ := doc.Bytes()
+	return string(bytes)
+}
+
+func (d *FileHandlerSteps) getUpdateRequest(uniqueSuffix string, patch jsonpatch.Patch) ([]byte, error) {
+	return helper.NewUpdateRequest(&helper.UpdateRequestInfo{
+		DidUniqueSuffix: uniqueSuffix,
+		Patch:           patch,
+		UpdateOTP:       docutil.EncodeToString([]byte(updateOTP)),
+		MultihashCode:   sha2_256,
+	})
+}
+
+func getFile(path string) []byte {
+	r, err := os.Open(path)
+	if err != nil {
+		panic(err)
+	}
+
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+func getUniqueSuffix(docID string) string {
+	pos := strings.LastIndex(docID, docutil.NamespaceDelimiter)
+	if pos == -1 {
+		return docID
+	}
+
+	return docID[pos+1:]
+}
+
+// UploadFile contains the file upload request
+type UploadFile struct {
+	ContentType string `json:"contentType"`
+	Content     []byte `json:"content"`
+}
+
 // RegisterSteps registers did sidetree steps
 func (d *FileHandlerSteps) RegisterSteps(s *godog.Suite) {
+	s.Step(`^client sends request to "([^"]*)" to create document with content "([^"]*)" in namespace "([^"]*)"$`, d.createDocument)
+	s.Step(`^client sends request to "([^"]*)" to update document "([^"]*)" with patch "([^"]*)"$`, d.updateDocument)
 	s.Step(`^client sends request to "([^"]*)" to retrieve file$`, d.resolveFile)
+	s.Step(`^client sends request to "([^"]*)" to upload file "([^"]*)" with content type "([^"]*)"$`, d.uploadFile)
+	s.Step(`^the ID of the file is saved to variable "([^"]*)"`, d.saveIDToVariable)
+	s.Step(`^the ID of the returned document is saved to variable "([^"]*)"`, d.saveDocIDToVariable)
+	s.Step(`^the retrieved file contains "([^"]*)"$`, d.retrievedFileContains)
 	s.Step(`^the response has status code (\d+) and error message "([^"]*)"$`, d.checkErrorResponse)
+	s.Step(`^variable "([^"]*)" is assigned the JSON patch '([^']*)'$`, d.setJSONPatchVar)
 }


### PR DESCRIPTION
The format of the file index document was changed such that it has explicit fields (as opposed to just a map of key-value pairs). Also, a document validator was added to validate create and update operations of the file index document.

This change required that the file-handler BDD test be reverted back to using file-handler steps and not the fabric-cli, since using the fabric-cli causes a circular dependency (i.e. fabric-cli depends on a sidetree-fabric image for BDD tests).

closes #165

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>