### PR TITLE
test: Use an implicit collection policy for document store

### DIFF
--- a/cmd/peer/go.mod
+++ b/cmd/peer/go.mod
@@ -15,7 +15,7 @@ replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.2
 
 replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200326141622-6322f4d89ac0
 
 replace github.com/trustbloc/sidetree-fabric => ../..
 

--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -341,8 +341,8 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.2 h1:xEbseWYXJ1QWT0jGIXVyrFXgduO2jRTFZWNLr8nMMY0=
 github.com/trustbloc/fabric-mod v0.1.2/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0 h1:diBO03DH5ZXqoJehzGH+Vvx2X5z/1/CgZFH1lBvsl2A=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200326141622-6322f4d89ac0 h1:RsdNQtZm/jTh6/ZRhP+UO8FTR942VtO3bZp25gHEmeE=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200326141622-6322f4d89ac0/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0 h1:DeboASCeoPwU4hl25QP5hbQ6QeJDiwyFkzeQkBXIcA0=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0/go.mod h1:x0at26YrCn4zhl15B2dPujacNRVc6Hi0VwK38jcSsZc=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.2
 
 replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200326141622-6322f4d89ac0
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2
 

--- a/go.sum
+++ b/go.sum
@@ -352,8 +352,8 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.2 h1:xEbseWYXJ1QWT0jGIXVyrFXgduO2jRTFZWNLr8nMMY0=
 github.com/trustbloc/fabric-mod v0.1.2/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0 h1:diBO03DH5ZXqoJehzGH+Vvx2X5z/1/CgZFH1lBvsl2A=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200304225705-4590f01205c0/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200326141622-6322f4d89ac0 h1:RsdNQtZm/jTh6/ZRhP+UO8FTR942VtO3bZp25gHEmeE=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200326141622-6322f4d89ac0/go.mod h1:oXudddhiBqcEGeEUAWfdh36pHYDdpP8x2Jy3s2GGL/g=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0 h1:DeboASCeoPwU4hl25QP5hbQ6QeJDiwyFkzeQkBXIcA0=
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200304225705-4590f01205c0/go.mod h1:x0at26YrCn4zhl15B2dPujacNRVc6Hi0VwK38jcSsZc=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -9,8 +9,8 @@
 Feature:
   Background: Setup
     Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "docs-mychannel" is defined for collection "docs" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
+    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
     And the channel "yourchannel" is created and all peers have joined

--- a/test/bddtests/features/file-handler.feature
+++ b/test/bddtests/features/file-handler.feature
@@ -9,8 +9,8 @@
 Feature:
   Background: Setup
     Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
-    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=60m
-    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=60m
+    Given off-ledger collection config "docs-mychannel" is defined for collection "docs" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
+    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
     And the channel "yourchannel" is created and all peers have joined

--- a/test/bddtests/features/sidetreetxn.feature
+++ b/test/bddtests/features/sidetreetxn.feature
@@ -9,8 +9,8 @@
 Feature:
   Background: Setup
     Given DCAS collection config "dcas-mychannel" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    Given DCAS collection config "docs-mychannel" is defined for collection "docs" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "docs-mychannel" is defined for collection "docs" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
+    Given off-ledger collection config "meta_data_coll" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
 

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -243,7 +243,7 @@ services:
       # metrics config
       - CORE_METRICS_PROVIDER=prometheus
       - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver
+      - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-observer
       # # the following setting starts chaincode containers on the same
       # # bridge network as the peers
       # # https://docs.docker.com/compose/networking/


### PR DESCRIPTION
The document and meta-data collections are changed to 'IMPLICIT-ORG' so that each org manages its own documents. Each org must have its own Observer.

closes #142

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>