### PR TITLE
refactor: docker image on clean base.

### DIFF
--- a/images/fabric-peer/Dockerfile
+++ b/images/fabric-peer/Dockerfile
@@ -1,30 +1,41 @@
-#
-# Copyright SecureKey Technologies Inc. All Rights Reserved.
+# Copyright SecureKey Technologies Inc. and the TrustBloc contributors. All Rights Reserved.
+# Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
+
+# Original image template from: https://github.com/hyperledger/fabric/tree/master/images/peer
 
 ARG GO_VER
 ARG ALPINE_VER
-ARG FABRIC_PEER_EXT_IMAGE
-ARG FABRIC_PEER_EXT_TAG
+ARG FABRIC_PEER_UPSTREAM_IMAGE
+ARG FABRIC_PEER_UPSTREAM_TAG
+
+FROM alpine:${ALPINE_VER} as peer-base
+RUN apk add --no-cache tzdata
+
+FROM ${FABRIC_PEER_UPSTREAM_IMAGE}:${FABRIC_PEER_UPSTREAM_TAG} as peer-upstream
 
 FROM golang:${GO_VER}-alpine${ALPINE_VER} as golang
 RUN apk add --no-cache \
-	gcc \
-	musl-dev \
-	git \
-	libtool \
 	bash \
-	make;
-ADD . $GOPATH/src/trustbloc/sidetree-fabric
-WORKDIR $GOPATH/src/trustbloc/sidetree-fabric
+	gcc \
+        binutils-gold \
+	git \
+	make \
+	musl-dev
+ADD . $GOPATH/src/github.com/trustbloc/sidetree-fabric
+WORKDIR $GOPATH/src/github.com/trustbloc/sidetree-fabric
+
+FROM golang as peer
 ARG GO_TAGS
-ARG GOPROXY
-RUN make GO_TAGS=${GO_TAGS} fabric-peer
+ARG GO_LDFLAGS
+RUN make GO_TAGS="${GO_TAGS}" GO_LDFLAGS="${GO_LDFLAGS}" fabric-peer
 
-
-
-FROM ${FABRIC_PEER_EXT_IMAGE}:${FABRIC_PEER_EXT_TAG}
-COPY --from=golang /go/src/trustbloc/sidetree-fabric/.build/bin /usr/local/bin
+FROM peer-base
+ENV FABRIC_CFG_PATH /etc/hyperledger/fabric
+VOLUME /etc/hyperledger/fabric
+VOLUME /var/hyperledger
+COPY --from=peer /go/src/github.com/trustbloc/sidetree-fabric/.build/bin /usr/local/bin
+COPY --from=peer-upstream ${FABRIC_CFG_PATH} ${FABRIC_CFG_PATH}
+EXPOSE 7051
 CMD ["fabric-peer"]


### PR DESCRIPTION
- copies files from upstream fabric image rather than basing on it.
- allows GO_LDFLAGS to be specified.
- allows image name and tag to be overriden.

Signed-off-by: Troy Ronda <troy.ronda@securekey.com>