### PR TITLE
feat: Add/remove public keys and service endpoints

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -349,8 +349,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289/go.mod h1:xRcVTvxZdAKBXWmbRNVATfiDUrs/JDB/xAxx7We76xY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec h1:NLaTbAuXXHJI1/xkL+YAvZlXvB+1kXb304wLYhkDIFk=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289/go.mod h1:xRcVTvxZdAKBXWmbRNVATfiDUrs/JDB/xAxx7We76xY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec h1:NLaTbAuXXHJI1/xkL+YAvZlXvB+1kXb304wLYhkDIFk=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -22,8 +22,10 @@ import (
 	"github.com/trustbloc/fabric-peer-test-common/bddtests"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/model"
+
 	"github.com/trustbloc/sidetree-fabric/test/bddtests/restclient"
 )
 
@@ -36,6 +38,27 @@ const (
 	recoveryOTP = "recoveryOTP"
 	updateOTP   = "updateOTP"
 )
+
+const addPublicKeysTemplate = `[
+	{
+      "id": "%s",
+      "usage": ["ops"],
+      "type": "Secp256k1VerificationKey2018",
+      "publicKeyHex": "02b97c30de767f084ce3080168ee293053ba33b235d7116a3263d29f1450936b71"
+    }
+  ]`
+
+const removePublicKeysTemplate = `["%s"]`
+
+const addServicesTemplate = `[
+    {
+      "id": "%s",
+      "type": "SecureDataStore",
+      "serviceEndpoint": "http://hub.my-personal-server.com"
+    }
+  ]`
+
+const removeServicesTemplate = `["%s"]`
 
 // DIDSideSteps
 type DIDSideSteps struct {
@@ -86,7 +109,15 @@ func (d *DIDSideSteps) checkErrorResp(errorMsg string) error {
 	return nil
 }
 
-func (d *DIDSideSteps) checkSuccessResp(msg string) error {
+func (d *DIDSideSteps) checkSuccessRespContains(msg string) error {
+	return d.checkSuccessResp(msg, true)
+}
+
+func (d *DIDSideSteps) checkSuccessRespDoesNotContain(msg string) error {
+	return d.checkSuccessResp(msg, false)
+}
+
+func (d *DIDSideSteps) checkSuccessResp(msg string, contains bool) error {
 	documentHash, err := d.getDID()
 	if err != nil {
 		return err
@@ -99,14 +130,24 @@ func (d *DIDSideSteps) checkSuccessResp(msg string) error {
 	if msg == "#didDocumentHash" {
 		msg = strings.Replace(msg, "#didDocumentHash", documentHash, -1)
 	}
-	logger.Infof("check success resp %s contain %s", string(d.resp.Payload), msg)
-	if !strings.Contains(string(d.resp.Payload), msg) {
+
+	action := " "
+	if !contains {
+		action = " NOT"
+	}
+
+	logger.Infof("check success resp %s MUST%s contain %s", string(d.resp.Payload), action, msg)
+	if contains && !strings.Contains(string(d.resp.Payload), msg) {
 		return errors.Errorf("success resp %s doesn't contain %s", d.resp.Payload, msg)
+	}
+
+	if !contains && strings.Contains(string(d.resp.Payload), msg) {
+		return errors.Errorf("success resp %s should NOT contain %s", d.resp.Payload, msg)
 	}
 	return nil
 }
 
-func (d *DIDSideSteps) updateDIDDocument(url, path, value string) error {
+func (d *DIDSideSteps) updateDIDDocument(url string, updatePatch patch.Patch) error {
 	uniqueSuffix, err := d.getUniqueSuffix()
 	if err != nil {
 		return err
@@ -114,7 +155,7 @@ func (d *DIDSideSteps) updateDIDDocument(url, path, value string) error {
 
 	logger.Infof("update did document: %s", uniqueSuffix)
 
-	req, err := getUpdateRequest(uniqueSuffix, path, value)
+	req, err := getUpdateRequest(uniqueSuffix, updatePatch)
 	if err != nil {
 		return err
 	}
@@ -207,6 +248,81 @@ func (d *DIDSideSteps) getUniqueSuffix() (string, error) {
 	return docutil.CalculateUniqueSuffix(createReq.SuffixData, sha2_256)
 }
 
+func (d *DIDSideSteps) updateDIDDocumentWithJSONPatch(url, path, value string) error {
+	updatePatch, err := getJSONPatch(path, value)
+	if err != nil {
+		return err
+	}
+
+	return d.updateDIDDocument(url, updatePatch)
+}
+
+func (d *DIDSideSteps) addPublicKeyToDIDDocument(url, keyID string) error {
+	updatePatch, err := getAddPublicKeysPatch(keyID)
+	if err != nil {
+		return err
+	}
+
+	return d.updateDIDDocument(url, updatePatch)
+}
+
+func (d *DIDSideSteps) removePublicKeyFromDIDDocument(url, keyID string) error {
+	updatePatch, err := getRemovePublicKeysPatch(keyID)
+	if err != nil {
+		return err
+	}
+
+	return d.updateDIDDocument(url, updatePatch)
+}
+
+func (d *DIDSideSteps) addServiceEndpointToDIDDocument(url, keyID string) error {
+	updatePatch, err := getAddServiceEndpointsPatch(keyID)
+	if err != nil {
+		return err
+	}
+
+	return d.updateDIDDocument(url, updatePatch)
+}
+
+func (d *DIDSideSteps) removeServiceEndpointsFromDIDDocument(url, keyID string) error {
+	updatePatch, err := getRemoveServiceEndpointsPatch(keyID)
+	if err != nil {
+		return err
+	}
+
+	return d.updateDIDDocument(url, updatePatch)
+}
+
+func getJSONPatch(path, value string) (patch.Patch, error) {
+	patchJSON := fmt.Sprintf(`[{"op": "replace", "path":  "%s", "value": "%s"}]`, path, value)
+	logger.Infof("creating JSON patch: %s", patchJSON)
+	return patch.NewJSONPatch(patchJSON)
+}
+
+func getAddPublicKeysPatch(keyID string) (patch.Patch, error) {
+	addPubKeys := fmt.Sprintf(addPublicKeysTemplate, keyID)
+	logger.Infof("creating add public keys patch: %s", addPubKeys)
+	return patch.NewAddPublicKeysPatch(addPubKeys)
+}
+
+func getRemovePublicKeysPatch(keyID string) (patch.Patch, error) {
+	removePubKeys := fmt.Sprintf(removePublicKeysTemplate, keyID)
+	logger.Infof("creating remove public keys patch: %s", removePubKeys)
+	return patch.NewRemovePublicKeysPatch(removePubKeys)
+}
+
+func getAddServiceEndpointsPatch(svcID string) (patch.Patch, error) {
+	addServices := fmt.Sprintf(addServicesTemplate, svcID)
+	logger.Infof("creating add service endpoints patch: %s", addServices)
+	return patch.NewAddServiceEndpointsPatch(addServices)
+}
+
+func getRemoveServiceEndpointsPatch(keyID string) (patch.Patch, error) {
+	removeServices := fmt.Sprintf(removeServicesTemplate, keyID)
+	logger.Infof("creating remove service endpoints patch: %s", removeServices)
+	return patch.NewRemoveServiceEndpointsPatch(removeServices)
+}
+
 func getCreateRequest(doc string) ([]byte, error) {
 	return helper.NewCreateRequest(&helper.CreateRequestInfo{
 		OpaqueDocument:          doc,
@@ -236,21 +352,14 @@ func getRevokeRequest(did string) ([]byte, error) {
 	})
 }
 
-func getUpdateRequest(did, path, value string) ([]byte, error) {
+func getUpdateRequest(did string, updatePatch patch.Patch) ([]byte, error) {
 	return helper.NewUpdateRequest(&helper.UpdateRequestInfo{
-		DidUniqueSuffix:   did,
-		UpdateRevealValue: []byte(updateOTP),
-		Patch:             getUpdatePatch(path, value),
-		MultihashCode:     sha2_256,
+		DidUniqueSuffix:       did,
+		UpdateRevealValue:     []byte(updateOTP),
+		NextUpdateRevealValue: []byte(updateOTP),
+		Patch:                 updatePatch,
+		MultihashCode:         sha2_256,
 	})
-}
-
-func getUpdatePatch(path, value string) string {
-	patchJSON := fmt.Sprintf(`[{"op": "replace", "path":  "%s", "value": "%s"}]`, path, value)
-
-	logger.Infof("JSON Patch: %s", patchJSON)
-
-	return patchJSON
 }
 
 func getOpaqueDocument(didDocumentPath string) string {
@@ -268,10 +377,15 @@ func getOpaqueDocument(didDocumentPath string) string {
 func (d *DIDSideSteps) RegisterSteps(s *godog.Suite) {
 	s.Step(`^check error response contains "([^"]*)"$`, d.checkErrorResp)
 	s.Step(`^client sends request to "([^"]*)" to create DID document "([^"]*)" in namespace "([^"]*)"$`, d.sendDIDDocument)
-	s.Step(`^client sends request to "([^"]*)" to update DID document path "([^"]*)" with value "([^"]*)"$`, d.updateDIDDocument)
+	s.Step(`^client sends request to "([^"]*)" to update DID document path "([^"]*)" with value "([^"]*)"$`, d.updateDIDDocumentWithJSONPatch)
+	s.Step(`^client sends request to "([^"]*)" to add public key with ID "([^"]*)" to DID document$`, d.addPublicKeyToDIDDocument)
+	s.Step(`^client sends request to "([^"]*)" to remove public key with ID "([^"]*)" from DID document$`, d.removePublicKeyFromDIDDocument)
+	s.Step(`^client sends request to "([^"]*)" to add service endpoint with ID "([^"]*)" to DID document$`, d.addServiceEndpointToDIDDocument)
+	s.Step(`^client sends request to "([^"]*)" to remove service endpoint with ID "([^"]*)" from DID document$`, d.removeServiceEndpointsFromDIDDocument)
 	s.Step(`^client sends request to "([^"]*)" to recover DID document "([^"]*)"$`, d.recoverDIDDocument)
 	s.Step(`^client sends request to "([^"]*)" to revoke DID document$`, d.revokeDIDDocument)
 	s.Step(`^client sends request to "([^"]*)" to resolve DID document with initial value$`, d.resolveDIDDocumentWithInitialValue)
-	s.Step(`^check success response contains "([^"]*)"$`, d.checkSuccessResp)
+	s.Step(`^check success response contains "([^"]*)"$`, d.checkSuccessRespContains)
+	s.Step(`^check success response does NOT contain "([^"]*)"$`, d.checkSuccessRespDoesNotContain)
 	s.Step(`^client sends request to "([^"]*)" to resolve DID document$`, d.resolveDIDDocument)
 }

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -166,3 +166,46 @@ Feature:
 
     When client sends request to "https://localhost:48526/document" to resolve DID document
     Then check success response contains "updatedValue"
+
+
+    @create_add_remove_public_key
+    Scenario: add and remove public keys
+    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+    Then check success response contains "#didDocumentHash"
+    And we wait 10 seconds
+
+    When client sends request to "https://localhost:48526/document" to resolve DID document
+    Then check success response contains "#didDocumentHash"
+
+    When client sends request to "https://localhost:48526/document" to add public key with ID "newKey" to DID document
+    Then we wait 10 seconds
+
+    When client sends request to "https://localhost:48526/document" to resolve DID document
+    Then check success response contains "newKey"
+
+    When client sends request to "https://localhost:48526/document" to remove public key with ID "newKey" from DID document
+    Then we wait 10 seconds
+
+    When client sends request to "https://localhost:48526/document" to resolve DID document
+    Then check success response does NOT contain "newKey"
+
+    @create_add_remove_services
+    Scenario: add and remove service endpoints
+    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+    Then check success response contains "#didDocumentHash"
+    And we wait 10 seconds
+
+    When client sends request to "https://localhost:48526/document" to resolve DID document
+    Then check success response contains "#didDocumentHash"
+
+    When client sends request to "https://localhost:48526/document" to add service endpoint with ID "newService" to DID document
+    Then we wait 10 seconds
+
+    When client sends request to "https://localhost:48526/document" to resolve DID document
+    Then check success response contains "newService"
+
+    When client sends request to "https://localhost:48526/document" to remove service endpoint with ID "newService" from DID document
+    Then we wait 10 seconds
+
+    When client sends request to "https://localhost:48526/document" to resolve DID document
+    Then check success response does NOT contain "newService"

--- a/test/bddtests/filehandler_steps.go
+++ b/test/bddtests/filehandler_steps.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/helper"
 
 	"github.com/trustbloc/sidetree-fabric/test/bddtests/restclient"
@@ -249,10 +250,15 @@ func (d *FileHandlerSteps) getOpaqueDocument(content string) string {
 	return string(bytes)
 }
 
-func (d *FileHandlerSteps) getUpdateRequest(uniqueSuffix string, patch string) ([]byte, error) {
+func (d *FileHandlerSteps) getUpdateRequest(uniqueSuffix string, jsonPatch string) ([]byte, error) {
+	updatePatch, err := patch.NewJSONPatch(jsonPatch)
+	if err != nil {
+		return nil, err
+	}
+
 	return helper.NewUpdateRequest(&helper.UpdateRequestInfo{
 		DidUniqueSuffix:   uniqueSuffix,
-		Patch:             patch,
+		Patch:             updatePatch,
 		UpdateRevealValue: []byte(updateOTP),
 		MultihashCode:     sha2_256,
 	})

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200326202528-57a0bf72f188
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -188,8 +188,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200326202528-57a0bf72f18
 github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200326202528-57a0bf72f188/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77 h1:WYVz7WkWqcqcTMEzHOm4u5NJmtefFAquamOneGHJvdI=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200331141546-1d1a08ef4a77/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec h1:NLaTbAuXXHJI1/xkL+YAvZlXvB+1kXb304wLYhkDIFk=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec/go.mod h1:qJ7oOPveEqrxTsO4KJsSHUM/Yivym221Dvd+IUq1V1U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Sidetree-core has been updated with two new features:
-- add/remove public keys patch
-- add/remove service endpoints patch

Add tests for both scenarios, update unit-tests

Closes #192

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>