### PR TITLE
test: Use cluster mode in BDD test for peers

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -36,6 +36,9 @@ jobs:
     - checkout: self
     - script: make bddtests
       displayName: Run BDD tests
+    - publish: test/bddtests/docker-compose.log
+      artifact: docker-compose.log
+      condition: always()
 
   - job: Publish
     dependsOn:

--- a/cmd/peer/go.mod
+++ b/cmd/peer/go.mod
@@ -13,9 +13,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200408213441-1e808f5039fb
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200331155411-318677a61289
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200408213441-1e808f5039fb
 
 replace github.com/trustbloc/sidetree-fabric => ../..
 

--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -343,10 +343,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230 h1:E0vsdhxeKNkgw6c5PF5TPaYNpAuRjyhkzXQgGzmVkRo=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200331155411-318677a61289 h1:vxNo8CRNTgyiGHPSIYUNUNZv74f39bCqSnmUM+OX39w=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200331155411-318677a61289/go.mod h1:w8VnrB48i/H61v53nvHSi+iMCo/zhKEmAkT2fsl68rA=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289 h1:3atxe6AHUKAa38Q0vZtBU0Jdzku7reXA5l04CXmuyYk=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289/go.mod h1:xRcVTvxZdAKBXWmbRNVATfiDUrs/JDB/xAxx7We76xY=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200408213441-1e808f5039fb h1:rc9HAq97l66XPPvC7rc2OxQ9R+3i0oOpOsEkZD1/mk4=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200408213441-1e808f5039fb/go.mod h1:w8VnrB48i/H61v53nvHSi+iMCo/zhKEmAkT2fsl68rA=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200408213441-1e808f5039fb h1:PO20U25AykrJ4jlTABZIlKjL8ZzVoGm5JlnK5VR2xUQ=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200408213441-1e808f5039fb/go.mod h1:xRcVTvxZdAKBXWmbRNVATfiDUrs/JDB/xAxx7We76xY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec h1:NLaTbAuXXHJI1/xkL+YAvZlXvB+1kXb304wLYhkDIFk=

--- a/go.mod
+++ b/go.mod
@@ -31,9 +31,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200408213441-1e808f5039fb
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200331155411-318677a61289
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200408213441-1e808f5039fb
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2
 

--- a/go.sum
+++ b/go.sum
@@ -354,10 +354,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230 h1:E0vsdhxeKNkgw6c5PF5TPaYNpAuRjyhkzXQgGzmVkRo=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200331030958-8bc4d7fd6230/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200331155411-318677a61289 h1:vxNo8CRNTgyiGHPSIYUNUNZv74f39bCqSnmUM+OX39w=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200331155411-318677a61289/go.mod h1:w8VnrB48i/H61v53nvHSi+iMCo/zhKEmAkT2fsl68rA=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289 h1:3atxe6AHUKAa38Q0vZtBU0Jdzku7reXA5l04CXmuyYk=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200331155411-318677a61289/go.mod h1:xRcVTvxZdAKBXWmbRNVATfiDUrs/JDB/xAxx7We76xY=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200408213441-1e808f5039fb h1:rc9HAq97l66XPPvC7rc2OxQ9R+3i0oOpOsEkZD1/mk4=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200408213441-1e808f5039fb/go.mod h1:w8VnrB48i/H61v53nvHSi+iMCo/zhKEmAkT2fsl68rA=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200408213441-1e808f5039fb h1:PO20U25AykrJ4jlTABZIlKjL8ZzVoGm5JlnK5VR2xUQ=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200408213441-1e808f5039fb/go.mod h1:xRcVTvxZdAKBXWmbRNVATfiDUrs/JDB/xAxx7We76xY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200402233141-19376f5cd0ec h1:NLaTbAuXXHJI1/xkL+YAvZlXvB+1kXb304wLYhkDIFk=

--- a/test/bddtests/bddtests_test.go
+++ b/test/bddtests/bddtests_test.go
@@ -84,8 +84,10 @@ func FeatureContext(s *godog.Suite) {
 	peersMspID := make(map[string]string)
 	peersMspID["peer0.org1.example.com"] = "Org1MSP"
 	peersMspID["peer1.org1.example.com"] = "Org1MSP"
+	peersMspID["peer2.org1.example.com"] = "Org1MSP"
 	peersMspID["peer0.org2.example.com"] = "Org2MSP"
 	peersMspID["peer1.org2.example.com"] = "Org2MSP"
+	peersMspID["peer2.org2.example.com"] = "Org2MSP"
 
 	var err error
 	context, err = bddtests.NewBDDContext([]string{"peerorg1", "peerorg2"}, "orderer.example.com", "./fixtures/config/sdk-client/",

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -9,12 +9,15 @@
 Feature:
   Background: Setup
     Given DCAS collection config "dcas-cfg" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    Given off-ledger collection config "diddoc-cfg" is defined for collection "diddoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
-    Given off-ledger collection config "fileidx-cfg" is defined for collection "fileidxdoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
-    Given off-ledger collection config "meta-data-cfg" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
+    Given off-ledger collection config "diddoc-cfg" is defined for collection "diddoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "fileidx-cfg" is defined for collection "fileidxdoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "meta-data-cfg" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
     And the channel "yourchannel" is created and all peers have joined
+
+    # Give the peers some time to gossip their new channel membership
+    And we wait 20 seconds
 
     And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
     And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
@@ -26,8 +29,8 @@ Feature:
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed
-    And fabric-cli context "mychannel" is defined on channel "mychannel" with org "peerorg1", peers "peer0.org1.example.com,peer1.org1.example.com" and user "User1"
-    And fabric-cli context "yourchannel" is defined on channel "yourchannel" with org "peerorg2", peers "peer0.org2.example.com,peer2.org1.example.com" and user "User1"
+    And fabric-cli context "mychannel" is defined on channel "mychannel" with org "peerorg1", peers "peer0.org1.example.com,peer1.org1.example.com,peer2.org1.example.com" and user "User1"
+    And fabric-cli context "yourchannel" is defined on channel "yourchannel" with org "peerorg2", peers "peer0.org2.example.com,peer1.org2.example.com,peer2.org2.example.com" and user "User1"
 
     And we wait 15 seconds
 
@@ -54,37 +57,37 @@ Feature:
 
   @create_did_doc
   Scenario: create valid did doc
-    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48426/document" to resolve DID document with initial value
-    Then check success response contains "#didDocumentHash"
-
-    And we wait 10 seconds
-
-    When client sends request to "https://localhost:48426/document" to resolve DID document
-    Then check success response contains "#didDocumentHash"
-
-    When client sends request to "https://localhost:48526/trustbloc.dev" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:bloc:trustbloc.dev"
-    Then check success response contains "#didDocumentHash"
-
-    When client sends request to "https://localhost:48426/trustbloc.dev" to resolve DID document with initial value
+    When client sends request to "https://localhost:48327/document" to resolve DID document with initial value
     Then check success response contains "#didDocumentHash"
 
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/trustbloc.dev" to resolve DID document
+    When client sends request to "https://localhost:48327/document" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48526/yourdomain.com" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:bloc:yourdomain.com"
+    When client sends request to "https://localhost:48426/trustbloc.dev" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:bloc:trustbloc.dev"
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48426/yourdomain.com" to resolve DID document with initial value
+    When client sends request to "https://localhost:48327/trustbloc.dev" to resolve DID document with initial value
     Then check success response contains "#didDocumentHash"
 
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/yourdomain.com" to resolve DID document
+    When client sends request to "https://localhost:48327/trustbloc.dev" to resolve DID document
+    Then check success response contains "#didDocumentHash"
+
+    When client sends request to "https://localhost:48426/yourdomain.com" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:bloc:yourdomain.com"
+    Then check success response contains "#didDocumentHash"
+
+    When client sends request to "https://localhost:48327/yourdomain.com" to resolve DID document with initial value
+    Then check success response contains "#didDocumentHash"
+
+    And we wait 10 seconds
+
+    When client sends request to "https://localhost:48327/yourdomain.com" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
   @batch_writer_recovery
@@ -92,6 +95,7 @@ Feature:
     # Stop all of the peers in org2 so that processing of the batch fails (since we need two orgs for endorsement).
     Given container "peer0.org2.example.com" is stopped
     And container "peer1.org2.example.com" is stopped
+    And container "peer2.org2.example.com" is stopped
     And we wait 2 seconds
 
     # Send the operation to peer0.org1.
@@ -108,13 +112,14 @@ Feature:
 
     Given container "peer0.org2.example.com" is started
     And container "peer1.org2.example.com" is started
+    And container "peer2.org2.example.com" is started
 
     # Wait for the peers to come up and the batch writer to cut the batch
     And we wait 30 seconds
 
     # Retrieve the document from another peer since, by this time, the operation should have
     # been processed and distributed to all peers.
-    When client sends request to "https://localhost:48626/document" to resolve DID document
+    When client sends request to "https://localhost:48427/document" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
   @invalid_config_update
@@ -126,86 +131,85 @@ Feature:
 
   @create_revoke_did_doc
   Scenario: create and revoke valid did doc
-    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "#didDocumentHash"
-    When client sends request to "https://localhost:48526/document" to revoke DID document
+    When client sends request to "https://localhost:48426/document" to revoke DID document
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check error response contains "document is no longer available"
 
   @create_recover_did_doc
   Scenario: create and recover did doc
-    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48526/document" to recover DID document "fixtures/testdata/recover.json"
+    When client sends request to "https://localhost:48426/document" to recover DID document "fixtures/testdata/recover.json"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "recoveryKey"
 
   @create_update_did_doc
   Scenario: create and update valid did doc
-    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "#didDocumentHash"
-    When client sends request to "https://localhost:48526/document" to update DID document path "/publicKey/0/type" with value "updatedValue"
+    When client sends request to "https://localhost:48426/document" to update DID document path "/publicKey/0/type" with value "updatedValue"
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "updatedValue"
 
-
-    @create_add_remove_public_key
-    Scenario: add and remove public keys
-    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+  @create_add_remove_public_key
+  Scenario: add and remove public keys
+    When client sends request to "https://localhost:48426/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48526/document" to add public key with ID "newKey" to DID document
+    When client sends request to "https://localhost:48426/document" to add public key with ID "newKey" to DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "newKey"
 
-    When client sends request to "https://localhost:48526/document" to remove public key with ID "newKey" from DID document
+    When client sends request to "https://localhost:48426/document" to remove public key with ID "newKey" from DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response does NOT contain "newKey"
 
-    @create_add_remove_services
-    Scenario: add and remove service endpoints
-    When client sends request to "https://localhost:48526/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
+  @create_add_remove_services
+  Scenario: add and remove service endpoints
+    When client sends request to "https://localhost:48426/document" to create DID document "fixtures/testdata/didDocument.json" in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48526/document" to add service endpoint with ID "newService" to DID document
+    When client sends request to "https://localhost:48426/document" to add service endpoint with ID "newService" to DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response contains "newService"
 
-    When client sends request to "https://localhost:48526/document" to remove service endpoint with ID "newService" from DID document
+    When client sends request to "https://localhost:48426/document" to remove service endpoint with ID "newService" from DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48526/document" to resolve DID document
+    When client sends request to "https://localhost:48426/document" to resolve DID document
     Then check success response does NOT contain "newService"

--- a/test/bddtests/features/file-handler.feature
+++ b/test/bddtests/features/file-handler.feature
@@ -9,12 +9,14 @@
 Feature:
   Background: Setup
     Given DCAS collection config "dcas-cfg" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    Given off-ledger collection config "diddoc-cfg" is defined for collection "diddoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
-    Given off-ledger collection config "fileidx-cfg" is defined for collection "fileidxdoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
-    Given off-ledger collection config "meta-data-cfg" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
+    Given off-ledger collection config "diddoc-cfg" is defined for collection "diddoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "fileidx-cfg" is defined for collection "fileidxdoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "meta-data-cfg" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
-    And the channel "yourchannel" is created and all peers have joined
+
+    # Give the peers some time to gossip their new channel membership
+    And we wait 20 seconds
 
     And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
     And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
@@ -25,7 +27,7 @@ Feature:
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed
-    And fabric-cli context "mychannel" is defined on channel "mychannel" with org "peerorg1", peers "peer0.org1.example.com,peer1.org1.example.com" and user "User1"
+    And fabric-cli context "mychannel" is defined on channel "mychannel" with org "peerorg1", peers "peer0.org1.example.com,peer1.org1.example.com,peer2.org1.example.com" and user "User1"
 
     And we wait 10 seconds
 
@@ -44,7 +46,7 @@ Feature:
     Then the ID of the file is saved to variable "arraysSchemaID"
     # Create the schema file index Sidetree document
     Given variable "schemaIndexFile" is assigned the JSON value '{"fileIndex":{"basePath":"/schema","mappings":{"arrays.schema.json":"${arraysSchemaID}"}}}'
-    When client sends request to "https://localhost:48526/file" to create document with content "${schemaIndexFile}" in namespace "file:idx"
+    When client sends request to "https://localhost:48426/file" to create document with content "${schemaIndexFile}" in namespace "file:idx"
     Then the ID of the returned document is saved to variable "schemaIndexID"
 
     # Upload .well-known files
@@ -56,14 +58,15 @@ Feature:
     Then the ID of the file is saved to variable "wellKnownOrg2ID"
     # Create the .well-known file index Sidetree document
     Given variable "wellKnownIndexFile" is assigned the JSON value '{"fileIndex":{"basePath":"/.well-known/did-bloc","mappings":{"trustbloc.dev.json":"${wellKnownTrustblocID}","org1.dev.json":"${wellKnownOrg1ID}","org2.dev.json":"${wellKnownOrg2ID}"}}}'
-    When client sends request to "https://localhost:48526/file" to create document with content "${wellKnownIndexFile}" in namespace "file:idx"
+    When client sends request to "https://localhost:48426/file" to create document with content "${wellKnownIndexFile}" in namespace "file:idx"
     Then the ID of the returned document is saved to variable "wellKnownIndexID"
+
 
     # Update the ledger config to point to the index file documents
     Given variable "schemaHandlerConfig" is assigned the JSON value '{"BasePath":"/schema","ChaincodeName":"file","Collection":"consortium","IndexNamespace":"file:idx","IndexDocID":"${schemaIndexID}"}'
     And variable "wellKnownHandlerConfig" is assigned the JSON value '{"BasePath":"/.well-known/did-bloc","ChaincodeName":"file","Collection":"consortium","IndexNamespace":"file:idx","IndexDocID":"${wellKnownIndexID}"}'
-    And variable "org1ConfigUpdate" is assigned the JSON value '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]},{"PeerID":"peer1.org1.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]}]}'
-    And variable "org2ConfigUpdate" is assigned the JSON value '{"MspID":"Org2MSP","Peers":[{"PeerID":"peer0.org2.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]},{"PeerID":"peer1.org2.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]}]}'
+    And variable "org1ConfigUpdate" is assigned the JSON value '{"MspID":"Org1MSP","Peers":[{"PeerID":"peer0.org1.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]},{"PeerID":"peer1.org1.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]},{"PeerID":"peer2.org1.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]}]}'
+    And variable "org2ConfigUpdate" is assigned the JSON value '{"MspID":"Org2MSP","Peers":[{"PeerID":"peer0.org2.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]},{"PeerID":"peer1.org2.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]},{"PeerID":"peer2.org2.example.com","Apps":[{"AppName":"file-handler","Version":"1","Components":[{"Name":"/schema","Version":"1","Config":"${schemaHandlerConfig}","Format":"json"},{"Name":"/.well-known/did-bloc","Version":"1","Config":"${wellKnownHandlerConfig}","Format":"json"}]}]}]}'
     And fabric-cli is executed with args "ledgerconfig update --config ${org1ConfigUpdate} --noprompt"
     And fabric-cli is executed with args "ledgerconfig update --config ${org2ConfigUpdate} --noprompt"
 
@@ -75,11 +78,11 @@ Feature:
     Then the response has status code 404 and error message "file not found"
 
     # Resolve .well-known files
-    When client sends request to "https://localhost:48626/.well-known/did-bloc/trustbloc.dev.json" to retrieve file
+    When client sends request to "https://localhost:48427/.well-known/did-bloc/trustbloc.dev.json" to retrieve file
     Then the JSON path "domain" of the response equals "trustbloc.dev"
-    When client sends request to "https://localhost:48626/.well-known/did-bloc/org1.dev.json" to retrieve file
+    When client sends request to "https://localhost:48427/.well-known/did-bloc/org1.dev.json" to retrieve file
     Then the JSON path "domain" of the response equals "org1.dev"
-    When client sends request to "https://localhost:48626/.well-known/did-bloc/org2.dev.json" to retrieve file
+    When client sends request to "https://localhost:48428/.well-known/did-bloc/org2.dev.json" to retrieve file
     Then the JSON path "domain" of the response equals "org2.dev"
 
     # Upload a new schema and update the schema index document
@@ -95,14 +98,14 @@ Feature:
 
     # Test invalid file index document (with missing basePath)
     Given variable "invalidIndexFile" is assigned the JSON value '{"fileIndex":{"basePath":""}}'
-    When client sends request to "https://localhost:48526/file" to create document with content "${invalidIndexFile}" in namespace "file:idx"
+    When client sends request to "https://localhost:48426/file" to create document with content "${invalidIndexFile}" in namespace "file:idx"
     Then the response has status code 500 and error message "missing base path"
 
   @duplicate_create_operation
   Scenario: Attempt to create the same index file on Sidetree twice. The second create operation should be rejected by the Observer.
     # Create the /content file index Sidetree document
     Given variable "contentIndexFile" is assigned the JSON value '{"fileIndex":{"basePath":"/content"}}'
-    When client sends request to "https://localhost:48526/file" to create document with content "${contentIndexFile}" in namespace "file:idx"
+    When client sends request to "https://localhost:48426/file" to create document with content "${contentIndexFile}" in namespace "file:idx"
     Then the ID of the returned document is saved to variable "contentIdxID"
     Then we wait 10 seconds
 
@@ -110,7 +113,7 @@ Feature:
     Then the JSON path "id" of the response equals "${contentIdxID}"
 
     # Attempt to create the /content file index Sidetree document again
-    When client sends request to "https://localhost:48526/file" to create document with content "${contentIndexFile}" in namespace "file:idx"
+    When client sends request to "https://localhost:48426/file" to create document with content "${contentIndexFile}" in namespace "file:idx"
     Then we wait 10 seconds
 
     # The Observer should have rejected the second create and the document resolver will not error out because of an invalid operation in the store

--- a/test/bddtests/features/sidetreetxn.feature
+++ b/test/bddtests/features/sidetreetxn.feature
@@ -9,11 +9,14 @@
 Feature:
   Background: Setup
     Given DCAS collection config "dcas-cfg" is defined for collection "dcas" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    Given off-ledger collection config "diddoc-cfg" is defined for collection "diddoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
-    Given off-ledger collection config "fileidx-cfg" is defined for collection "fileidxdoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
-    Given off-ledger collection config "meta-data-cfg" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=1, and timeToLive=
+    Given off-ledger collection config "diddoc-cfg" is defined for collection "diddoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "fileidx-cfg" is defined for collection "fileidxdoc" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
+    Given off-ledger collection config "meta-data-cfg" is defined for collection "meta_data" as policy="OR('IMPLICIT-ORG.member')", requiredPeerCount=0, maxPeerCount=0, and timeToLive=
 
     Given the channel "mychannel" is created and all peers have joined
+
+    # Give the peers some time to gossip their new channel membership
+    And we wait 20 seconds
 
     And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
     And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
@@ -21,7 +24,7 @@ Feature:
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed
-    And fabric-cli context "mychannel" is defined on channel "mychannel" with org "peerorg1", peers "peer0.org1.example.com,peer1.org1.example.com" and user "User1"
+    And fabric-cli context "mychannel" is defined on channel "mychannel" with org "peerorg1", peers "peer0.org1.example.com,peer1.org1.example.com,peer2.org1.example.com" and user "User1"
 
     And we wait 10 seconds
 

--- a/test/bddtests/fixtures/config/fabric/mychannel-org1-config.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-org1-config.json
@@ -94,6 +94,53 @@
           ]
         }
       ]
+    },
+    {
+      "PeerID": "peer2.org1.example.com",
+      "Apps": [
+        {
+          "AppName": "txn",
+          "Version": "1",
+          "Components": [
+            {
+              "Name": "general",
+              "Version": "1",
+              "Config": "file://./txn-config.json",
+              "Format": "json"
+            },
+            {
+              "Name": "sdk",
+              "Version": "1",
+              "Config": "file://./sdk-config-org1.yaml",
+              "Format": "yaml"
+            }
+          ]
+        },
+        {
+          "AppName": "sidetree",
+          "Version": "1",
+          "Config": "file://./mychannel-sidetree-config-org1.json",
+          "Format": "json"
+        },
+        {
+          "AppName": "file-handler",
+          "Version": "1",
+          "Components": [
+            {
+              "Name": "/schema",
+              "Version": "1",
+              "Config": "file://./mychannel-filehandler-schema-config.json",
+              "Format": "json"
+            },
+            {
+              "Name": "/.well-known/did-bloc",
+              "Version": "1",
+              "Config": "file://./mychannel-filehandler-wellknown-config.json",
+              "Format": "json"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/bddtests/fixtures/config/fabric/mychannel-org2-config.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-org2-config.json
@@ -94,6 +94,53 @@
           ]
         }
       ]
+    },
+    {
+      "PeerID": "peer2.org2.example.com",
+      "Apps": [
+        {
+          "AppName": "txn",
+          "Version": "1",
+          "Components": [
+            {
+              "Name": "general",
+              "Version": "1",
+              "Config": "file://./txn-config.json",
+              "Format": "json"
+            },
+            {
+              "Name": "sdk",
+              "Version": "1",
+              "Config": "file://./sdk-config-org2.yaml",
+              "Format": "yaml"
+            }
+          ]
+        },
+        {
+          "AppName": "sidetree",
+          "Version": "1",
+          "Config": "file://./mychannel-sidetree-config-org2.json",
+          "Format": "json"
+        },
+        {
+          "AppName": "file-handler",
+          "Version": "1",
+          "Components": [
+            {
+              "Name": "/schema",
+              "Version": "1",
+              "Config": "file://./mychannel-filehandler-schema-config.json",
+              "Format": "json"
+            },
+            {
+              "Name": "/.well-known/did-bloc",
+              "Version": "1",
+              "Config": "file://./mychannel-filehandler-wellknown-config.json",
+              "Format": "json"
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/test/bddtests/fixtures/config/fabric/yourchannel-org1-config.json
+++ b/test/bddtests/fixtures/config/fabric/yourchannel-org1-config.json
@@ -58,6 +58,35 @@
           "Format": "json"
         }
       ]
+    },
+    {
+      "PeerID": "peer2.org1.example.com",
+      "Apps": [
+        {
+          "AppName": "txn",
+          "Version": "1",
+          "Components": [
+            {
+              "Name": "general",
+              "Version": "1",
+              "Config": "file://./txn-config.json",
+              "Format": "json"
+            },
+            {
+              "Name": "sdk",
+              "Version": "1",
+              "Config": "file://./sdk-config-org1.yaml",
+              "Format": "yaml"
+            }
+          ]
+        },
+        {
+          "AppName": "sidetree",
+          "Version": "1",
+          "Config": "file://./yourchannel-sidetree-config-org1.json",
+          "Format": "json"
+        }
+      ]
     }
   ]
 }

--- a/test/bddtests/fixtures/config/fabric/yourchannel-org2-config.json
+++ b/test/bddtests/fixtures/config/fabric/yourchannel-org2-config.json
@@ -58,6 +58,35 @@
           "Format": "json"
         }
       ]
+    },
+    {
+      "PeerID": "peer2.org2.example.com",
+      "Apps": [
+        {
+          "AppName": "txn",
+          "Version": "1",
+          "Components": [
+            {
+              "Name": "general",
+              "Version": "1",
+              "Config": "file://./txn-config.json",
+              "Format": "json"
+            },
+            {
+              "Name": "sdk",
+              "Version": "1",
+              "Config": "file://./sdk-config-org2.yaml",
+              "Format": "yaml"
+            }
+          ]
+        },
+        {
+          "AppName": "sidetree",
+          "Version": "1",
+          "Config": "file://./yourchannel-sidetree-config-org2.json",
+          "Format": "json"
+        }
+      ]
     }
   ]
 }

--- a/test/bddtests/fixtures/config/sdk-client/config.yaml
+++ b/test/bddtests/fixtures/config/sdk-client/config.yaml
@@ -44,8 +44,8 @@ client:
       registrationResponse: 10s
   orderer:
     timeout:
-      connection: 3s
-      response: 10s
+      connection: 30s
+      response: 60s
   global:
     timeout:
       query: 120s
@@ -160,7 +160,7 @@ channels:
     # Required. list of peers from participating orgs
     peers:
       peer0.org1.example.com:
-        endorsingPeer: true
+        endorsingPeer: false
         chaincodeQuery: true
         ledgerQuery: true
         eventSource: true
@@ -171,13 +171,25 @@ channels:
         ledgerQuery: true
         eventSource: true
 
-      peer0.org2.example.com:
+      peer2.org1.example.com:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
         eventSource: true
 
+      peer0.org2.example.com:
+        endorsingPeer: false
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+
       peer1.org2.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+
+      peer2.org2.example.com:
         endorsingPeer: true
         chaincodeQuery: true
         ledgerQuery: true
@@ -187,7 +199,7 @@ channels:
     # Required. list of peers from participating orgs
     peers:
       peer0.org1.example.com:
-        endorsingPeer: true
+        endorsingPeer: false
         chaincodeQuery: true
         ledgerQuery: true
         eventSource: true
@@ -198,8 +210,14 @@ channels:
         ledgerQuery: true
         eventSource: true
 
-      peer0.org2.example.com:
+      peer2.org1.example.com:
         endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
+
+      peer0.org2.example.com:
+        endorsingPeer: false
         chaincodeQuery: true
         ledgerQuery: true
         eventSource: true
@@ -210,6 +228,11 @@ channels:
         ledgerQuery: true
         eventSource: true
 
+      peer2.org2.example.com:
+        endorsingPeer: true
+        chaincodeQuery: true
+        ledgerQuery: true
+        eventSource: true
 
 orderers:
   orderer.example.com:
@@ -250,6 +273,7 @@ organizations:
     peers:
       - peer0.org1.example.com
       - peer1.org1.example.com
+      - peer2.org1.example.com
 
     # [Optional]. Certificate Authorities issue certificates for identification purposes in a Fabric based
     # network. Typically certificates provisioning is done in a separate process outside of the
@@ -270,6 +294,7 @@ organizations:
     peers:
       - peer0.org2.example.com
       - peer1.org2.example.com
+      - peer2.org2.example.com
 
     # [Optional]. Certificate Authorities issue certificates for identification purposes in a Fabric based
     # network. Typically certificates provisioning is done in a separate process outside of the
@@ -326,6 +351,17 @@ peers:
       # Certificate location absolute path
       path: ${PROJECT_PATH}/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
 
+  peer2.org1.example.com:
+    # this URL is used to send endorsement and query requests
+    url: localhost:7251
+
+    grpcOptions:
+      ssl-target-name-override: peer2.org1.example.com
+
+    tlsCACerts:
+      # Certificate location absolute path
+      path: ${PROJECT_PATH}/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/org1.example.com/tlsca/tlsca.org1.example.com-cert.pem
+
   peer0.org2.example.com:
     # this URL is used to send endorsement and query requests
     url: localhost:8051
@@ -348,6 +384,17 @@ peers:
       # Certificate location absolute path
       path: ${PROJECT_PATH}/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
 
+  peer2.org2.example.com:
+    # this URL is used to send endorsement and query requests
+    url: localhost:8251
+
+    grpcOptions:
+      ssl-target-name-override: peer2.org2.example.com
+
+    tlsCACerts:
+      # Certificate location absolute path
+      path: ${PROJECT_PATH}/test/bddtests/fixtures/fabric/crypto-config/peerOrganizations/org2.example.com/tlsca/tlsca.org2.example.com-cert.pem
+
 entityMatchers:
   peer:
     - pattern: peer0.org1.example.com:(\d+)
@@ -358,6 +405,10 @@ entityMatchers:
       urlSubstitutionExp: localhost:7151
       mappedHost: peer1.org1.example.com
 
+    - pattern: peer2.org1.example.com:(\d+)
+      urlSubstitutionExp: localhost:7251
+      mappedHost: peer2.org1.example.com
+
     - pattern: peer0.org2.example.com:(\d+)
       urlSubstitutionExp: localhost:8051
       mappedHost: peer0.org2.example.com
@@ -365,6 +416,10 @@ entityMatchers:
     - pattern: peer1.org2.example.com:(\d+)
       urlSubstitutionExp: localhost:8151
       mappedHost: peer1.org2.example.com
+
+    - pattern: peer2.org2.example.com:(\d+)
+      urlSubstitutionExp: localhost:8251
+      mappedHost: peer2.org2.example.com
 
   orderer:
     - pattern: (\w+).example.(\w+)

--- a/test/bddtests/fixtures/docker-compose-base.yml
+++ b/test/bddtests/fixtures/docker-compose-base.yml
@@ -1,0 +1,53 @@
+#
+# Copyright IBM Corp, SecureKey Technologies Inc. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+version: '2'
+
+services:
+  peer:
+    image: ${FABRIC_PEER_FIXTURE_IMAGE}:latest
+    environment:
+      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
+      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:endorser=warn:sidetree_peer=debug:sidetree_context=debug:sidetree_observer=debug:ext_offledger=info:ext_dispatcher=info:chaincode=info:cceventmgmt=info:ext_gossip_state=info:info
+      ## the following setting redirects chaincode container logs to the peer container logs
+      - CORE_VM_DOCKER_ATTACHSTDOUT=true
+      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
+      - CORE_PEER_TLS_ENABLED=true
+      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
+      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
+      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
+      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
+      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
+      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
+      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
+      # override chaincode images
+      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
+      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
+      # metrics config
+      - CORE_METRICS_PROVIDER=prometheus
+      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
+      # # the following setting starts chaincode containers on the same
+      # # bridge network as the peers
+      # # https://docs.docker.com/compose/networking/
+      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
+      # CouchDB Settings
+      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
+      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
+      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
+      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
+      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=MSP
+      - CORE_COLL_OFFLEDGER_CACHE_ENABLE=false
+      - CORE_SIDETREE_PORT=48326
+      - CORE_SIDETREE_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
+      - CORE_SIDETREE_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
+    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
+    tty: true
+    volumes:
+      - /var/run/:/host/var/run/
+      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
+      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
+      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml

--- a/test/bddtests/fixtures/docker-compose.yml
+++ b/test/bddtests/fixtures/docker-compose.yml
@@ -38,246 +38,133 @@ services:
         - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/etc/hyperledger/msp/orderer
         - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/etc/hyperledger/tls/orderer
         - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls/ca.crt:/etc/hyperledger/mutual_tls/orderer/ca.crt
+
   peer0.org1.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer0.org1.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:endorser=warn:sidetree_peer=debug:sidetree_context=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer0.org1.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org1.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      - CORE_LEDGER_ROLES=endorser,committer,sidetree-batch-writer,sidetree-resolver,sidetree-monitor
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
-      - CORE_COLL_OFFLEDGER_CACHE_ENABLE=true
-      - CORE_SIDETREE_PORT=48326
-      - CORE_SIDETREE_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_SIDETREE_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
+      - CORE_LEDGER_ROLES=committer,sidetree-batch-writer,sidetree-resolver,sidetree-observer,sidetree-monitor
     ports:
       - 7051:7051
       - 48326:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/etc/hyperledger/fabric/tls
-      # Give Snap the orderer CA
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
 
   peer1.org1.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer1.org1.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org1.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:endorser=warn:sidetree_peer=debug:sidetree_context=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org1MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer1.org1.example.com:7051
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org1.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer1.org1.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-observer
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
-      - CORE_COLL_OFFLEDGER_CACHE_ENABLE=true
-      - CORE_SIDETREE_PORT=48326
-      - CORE_SIDETREE_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_SIDETREE_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
+      - CORE_LEDGER_ROLES=endorser,sidetree-batch-writer,sidetree-resolver
     ports:
       - 7151:7051
-      - 48426:48326
+      - 48327:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer1.org1.example.com/tls:/etc/hyperledger/fabric/tls
-      # Give Snap the orderer CA
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
+    depends_on:
+      - builder
+      - orderer.example.com
+
+  peer2.org1.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
+    container_name: peer2.org1.example.com
+    environment:
+      - CORE_PEER_ID=peer2.org1.example.com
+      - CORE_PEER_LOCALMSPID=Org1MSP
+      - CORE_PEER_ADDRESS=peer2.org1.example.com:7051
+      - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org1.example.com:7051
+      - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer2.org1.example.com:7051
+      - CORE_LEDGER_ROLES=endorser,sidetree-batch-writer,sidetree-resolver
+    ports:
+      - 7251:7051
+      - 48328:48326
+    volumes:
+      - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer2.org1.example.com/msp:/etc/hyperledger/msp/peer
+      - ./fabric/crypto-config/peerOrganizations/org1.example.com/peers/peer2.org1.example.com/tls:/etc/hyperledger/fabric/tls
     depends_on:
       - builder
       - orderer.example.com
 
   peer0.org2.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer0.org2.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer0.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:endorser=warn:sidetree_peer=debug:sidetree_context=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer0.org2.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer0.org2.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-batch-writer,sidetree-monitor
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
-      - CORE_COLL_OFFLEDGER_CACHE_ENABLE=true
-      - CORE_SIDETREE_PORT=48326
-      - CORE_SIDETREE_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_SIDETREE_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
+      - CORE_LEDGER_ROLES=committer,sidetree-batch-writer,sidetree-resolver,sidetree-observer,sidetree-monitor
     ports:
       - 8051:7051
-      - 48526:48326
+      - 48426:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls:/etc/hyperledger/fabric/tls
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
     depends_on:
       - builder
       - orderer.example.com
 
   peer1.org2.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
     container_name: peer1.org2.example.com
-    image: ${FABRIC_PEER_FIXTURE_IMAGE}:latest
     environment:
-      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ID=peer1.org2.example.com
-      - FABRIC_LOGGING_SPEC=comm.grpc.server=error:cauthdsl=warn:gossip=warn:grpc=warn:ledger=info:msp=warn:policies=warn:peer.gossip=warn:endorser=warn:sidetree_peer=debug:sidetree_context=debug:info
-      ## the following setting redirects chaincode container logs to the peer container logs
-      - CORE_VM_DOCKER_ATTACHSTDOUT=true
       - CORE_PEER_LOCALMSPID=Org2MSP
-      - CORE_PEER_MSPCONFIGPATH=/etc/hyperledger/msp/peer/
       - CORE_PEER_ADDRESS=peer1.org2.example.com:7051
       - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org2.example.com:7051
       - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer1.org2.example.com:7051
-      - CORE_PEER_TLS_ENABLED=true
-      - CORE_PEER_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_CLIENTCERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_PEER_TLS_CLIENTKEY_FILE=/etc/hyperledger/fabric/tls/server.key
-      - CORE_PEER_TLS_ROOTCERT_FILE=/etc/hyperledger/fabric/tls/ca.crt
-      - CORE_PEER_TLS_CLIENTAUTHREQUIRED=true
-      - CORE_PEER_TLS_CLIENTROOTCAS_FILES=/etc/hyperledger/fabric/tls/ca.crt /etc/hyperledger/mutual_tls/peer/ca.crt
-      # override chaincode images
-      - CORE_CHAINCODE_BUILDER=${TRUSTBLOCK_NS}/${FABRIC_BUILDER_FIXTURE_IMAGE}:${ARCH}-${FABRIC_BUILDER_FIXTURE_TAG}
-      - CORE_CHAINCODE_GOLANG_RUNTIME=${FABRIC_NS}/${FABRIC_BASEOS_FIXTURE_IMAGE}:${FABRIC_BASEOS_FIXTURE_TAG}
-      # metrics config
-      - CORE_METRICS_PROVIDER=prometheus
-      - CORE_OPERATIONS_LISTENADDRESS=0.0.0.0:8080
-      - CORE_LEDGER_ROLES=endorser,committer,sidetree-resolver,sidetree-observer
-      # # the following setting starts chaincode containers on the same
-      # # bridge network as the peers
-      # # https://docs.docker.com/compose/networking/
-      - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=fixtures_default
-      # CouchDB Settings
-      - CORE_LEDGER_STATE_STATEDATABASE=CouchDB
-      - CORE_LEDGER_TRANSIENTDATA_CACHESIZE=1000
-      - CORE_LEDGER_TRANSIENTDATA_CLEANUPEXPIRED_INTERVAL=5s
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME=cdbadmin
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD=secret
-      - CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS=shared.couchdb:5984
-      - CORE_LEDGER_STATE_DBCONFIG_PARTITIONTYPE=PEER
-      - CORE_COLL_OFFLEDGER_CACHE_ENABLE=true
-      - CORE_SIDETREE_PORT=48326
-      - CORE_SIDETREE_TLS_CERT_FILE=/etc/hyperledger/fabric/tls/server.crt
-      - CORE_SIDETREE_TLS_KEY_FILE=/etc/hyperledger/fabric/tls/server.key
-    working_dir: /opt/gopath/src/github.com/hyperledger/fabric
-    tty: true
+      - CORE_LEDGER_ROLES=endorser,sidetree-batch-writer,sidetree-resolver
     ports:
       - 8151:7051
-      - 48626:48326
+      - 48427:48326
     volumes:
-      - /var/run/:/host/var/run/
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/msp:/etc/hyperledger/msp/peer
       - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer1.org2.example.com/tls:/etc/hyperledger/fabric/tls
-      - ./fabric/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/ca.crt:/etc/hyperledger/fabric/tls/orderer-ca-cert.pem
-      - ./fabric/crypto-config/peerOrganizations/tls.example.com/users/User1@tls.example.com/tls:/etc/hyperledger/mutual_tls/peer
-      - ${COMPOSE_DIR}/config/fabric/core.yaml:/etc/hyperledger/fabric/core.yaml
+    depends_on:
+      - builder
+      - orderer.example.com
+
+  peer2.org2.example.com:
+    extends:
+      file: docker-compose-base.yml
+      service: peer
+    container_name: peer2.org2.example.com
+    environment:
+      - CORE_PEER_ID=peer2.org2.example.com
+      - CORE_PEER_LOCALMSPID=Org2MSP
+      - CORE_PEER_ADDRESS=peer2.org2.example.com:7051
+      - CORE_PEER_GOSSIP_BOOTSTRAP=peer0.org2.example.com:7051
+      - CORE_PEER_GOSSIP_EXTERNALENDPOINT=peer2.org2.example.com:7051
+      - CORE_LEDGER_ROLES=endorser,sidetree-batch-writer,sidetree-resolver
+    ports:
+      - 8251:7051
+      - 48428:48326
+    volumes:
+      - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer2.org2.example.com/msp:/etc/hyperledger/msp/peer
+      - ./fabric/crypto-config/peerOrganizations/org2.example.com/peers/peer2.org2.example.com/tls:/etc/hyperledger/fabric/tls
     depends_on:
       - builder
       - orderer.example.com

--- a/test/bddtests/fixtures/fabric/config/configtx.yaml
+++ b/test/bddtests/fixtures/fabric/config/configtx.yaml
@@ -89,6 +89,8 @@ Organizations:
               Port: 7051
             - Host: peer1.org1.example.com
               Port: 7051
+            - Host: peer2.org1.example.com
+              Port: 7051
 
     - &Org2
         # DefaultOrg defines the organization which is used in the sampleconfig
@@ -127,6 +129,8 @@ Organizations:
             - Host: peer0.org2.example.com
               Port: 7051
             - Host: peer1.org2.example.com
+              Port: 7051
+            - Host: peer2.org2.example.com
               Port: 7051
 
 

--- a/test/bddtests/fixtures/fabric/config/cryptogen.yaml
+++ b/test/bddtests/fixtures/fabric/config/cryptogen.yaml
@@ -13,14 +13,14 @@ PeerOrgs:
   - Name: Org1
     Domain: org1.example.com
     Template:
-      Count: 2
+      Count: 3
     Users:
       Count: 1
 
   - Name: Org2
     Domain: org2.example.com
     Template:
-      Count: 2
+      Count: 3
     Users:
       Count: 1
 


### PR DESCRIPTION
- Added another peer to each org so that there are two endorsers and one committer
- The sidetree-observer and sidetree-monitor roles were set to the committer, since both roles require writes to the DB
- Caching was turned off since there's a potential bug (https://github.com/trustbloc/fabric-peer-ext/issues/382)

closes #173

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>