### PR TITLE
refactor: Refactored blockchain scanner to allow for custom iterators/scanners

### DIFF
--- a/cmd/peer/go.mod
+++ b/cmd/peer/go.mod
@@ -13,9 +13,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200420211837-817e574a362d
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200420211837-817e574a362d
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200421205558-934bc094d380
 
 replace github.com/trustbloc/sidetree-fabric => ../..
 

--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -361,10 +361,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50 h1:9RFVqWlVHlygbVY33iW0M6K4WupuR+tm/qnxIoNtZM8=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200420211837-817e574a362d h1:vsfkERfLye5n1SyEZxijXIQ7v+N/ZYXLuqm0gCFDpYE=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200420211837-817e574a362d/go.mod h1:ksCmofudtbAmuWfEkbPD/VDzpL1jQHAae38DzoUGUoA=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200420211837-817e574a362d h1:CnXz7QzRr/bTreMHnuqEjOPCiYPwnB20sBFRgZ4mh50=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200420211837-817e574a362d/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200421205558-934bc094d380 h1:hTljHGYU+5ypoNM867o3p+nhfvSwGMR35/4XTGYkGwk=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200421205558-934bc094d380/go.mod h1:LiRbXLspIzwB4+266oPVieGXglHLYFpzwuRQM+P8lxk=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380 h1:GDvS0j4wRI0n559VTIr/JBOtpHxK4d89HeACEIL5o78=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420215423-0c6a32299a30 h1:bd/u3vgi2ZGYBenKTooTV9FiYMfIkhzCTXt/nAUiDmg=

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/Shopify/sarama v1.22.1 // indirect
 	github.com/bluele/gcache v0.0.0-20190301044115-79ae3b2d8680
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
+	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible
 	github.com/gorilla/mux v1.7.3
 	github.com/hyperledger/fabric v2.0.0+incompatible
@@ -29,9 +30,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200420211837-817e574a362d
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200420211837-817e574a362d
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200421205558-934bc094d380
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2
 

--- a/go.sum
+++ b/go.sum
@@ -372,10 +372,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50 h1:9RFVqWlVHlygbVY33iW0M6K4WupuR+tm/qnxIoNtZM8=
 github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200420211837-817e574a362d h1:vsfkERfLye5n1SyEZxijXIQ7v+N/ZYXLuqm0gCFDpYE=
-github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200420211837-817e574a362d/go.mod h1:ksCmofudtbAmuWfEkbPD/VDzpL1jQHAae38DzoUGUoA=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200420211837-817e574a362d h1:CnXz7QzRr/bTreMHnuqEjOPCiYPwnB20sBFRgZ4mh50=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200420211837-817e574a362d/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200421205558-934bc094d380 h1:hTljHGYU+5ypoNM867o3p+nhfvSwGMR35/4XTGYkGwk=
+github.com/trustbloc/fabric-peer-ext v0.1.3-0.20200421205558-934bc094d380/go.mod h1:LiRbXLspIzwB4+266oPVieGXglHLYFpzwuRQM+P8lxk=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380 h1:GDvS0j4wRI0n559VTIr/JBOtpHxK4d89HeACEIL5o78=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3-0.20200420215423-0c6a32299a30 h1:bd/u3vgi2ZGYBenKTooTV9FiYMfIkhzCTXt/nAUiDmg=

--- a/pkg/rest/blockchainhandler/blockchainscanner_test.go
+++ b/pkg/rest/blockchainhandler/blockchainscanner_test.go
@@ -14,6 +14,7 @@ import (
 	pb "github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+
 	"github.com/trustbloc/sidetree-fabric/pkg/observer/common"
 	obmocks "github.com/trustbloc/sidetree-fabric/pkg/observer/mocks"
 )
@@ -35,38 +36,20 @@ func TestBlockchainScanner(t *testing.T) {
 	bcClient := &obmocks.BlockchainClient{}
 
 	t.Run("Success", func(t *testing.T) {
-		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
 		bcClient.GetBlockByNumberReturns(bb.Build(), nil)
 
-		v := newBlockchainScanner(channel1, 1, 0, 10, bcClient)
-		require.NotNil(t, v)
-		resp, err := v.scan()
+		resp, err := scanBlockchain(channel1, 10, newBlockScanner(channel1, bcClient), newBlockIterator(bcInfo, 1, 0))
 		require.NoError(t, err)
 		require.Len(t, resp.Transactions, 2)
 	})
 
 	t.Run("Maximum reached", func(t *testing.T) {
-		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
 		bcClient.GetBlockByNumberReturns(bb.Build(), nil)
 
-		v := newBlockchainScanner(channel1, 1, 0, 0, bcClient)
-		require.NotNil(t, v)
-		resp, err := v.scan()
+		resp, err := scanBlockchain(channel1, 0, newBlockScanner(channel1, bcClient), newBlockIterator(bcInfo, 1, 0))
 		require.NoError(t, err)
 		require.True(t, resp.More)
 		require.Empty(t, resp.Transactions)
-	})
-
-	t.Run("Blockchain client error", func(t *testing.T) {
-		errExpected := errors.New("injected blockchain client error")
-		bcClient.GetBlockchainInfoReturns(nil, errExpected)
-
-		v := newBlockchainScanner(channel1, 1, 0, 10, bcClient)
-		require.NotNil(t, v)
-		resp, err := v.scan()
-		require.Error(t, err)
-		require.Contains(t, err.Error(), errExpected.Error())
-		require.Nil(t, resp)
 	})
 
 	t.Run("GetBlockByNumber error", func(t *testing.T) {
@@ -74,9 +57,7 @@ func TestBlockchainScanner(t *testing.T) {
 		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
 		bcClient.GetBlockByNumberReturns(nil, errExpected)
 
-		v := newBlockchainScanner(channel1, 1, 0, 0, bcClient)
-		require.NotNil(t, v)
-		resp, err := v.scan()
+		resp, err := scanBlockchain(channel1, 0, newBlockScanner(channel1, bcClient), newBlockIterator(bcInfo, 1, 0))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), errExpected.Error())
 		require.Nil(t, resp)

--- a/pkg/rest/blockchainhandler/blockiterator.go
+++ b/pkg/rest/blockchainhandler/blockiterator.go
@@ -1,0 +1,55 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockchainhandler
+
+import (
+	cb "github.com/hyperledger/fabric-protos-go/common"
+)
+
+type blockIterator struct {
+	currentBlockNum uint64
+	sinceTxnNum     uint64
+	height          uint64
+}
+
+type blockDesc struct {
+	blockNum uint64
+	txnNum   uint64
+}
+
+func (d *blockDesc) BlockNum() uint64 {
+	return d.blockNum
+}
+
+func (d *blockDesc) TxnNum() uint64 {
+	return d.txnNum
+}
+
+func newBlockIterator(bcInfo *cb.BlockchainInfo, sinceBlockNum, sinceTxnNum uint64) *blockIterator {
+	return &blockIterator{
+		currentBlockNum: sinceBlockNum,
+		sinceTxnNum:     sinceTxnNum,
+		height:          bcInfo.Height,
+	}
+}
+
+func (it *blockIterator) Next() (BlockDescriptor, bool) {
+	if it.currentBlockNum == it.height {
+		return nil, false
+	}
+
+	desc := &blockDesc{
+		blockNum: it.currentBlockNum,
+		txnNum:   it.sinceTxnNum,
+	}
+
+	// Reset sinceTxnNum to 0 since it only applies to the first block
+	it.sinceTxnNum = 0
+	it.currentBlockNum++
+
+	return desc, true
+}

--- a/pkg/rest/blockchainhandler/blockiterator_test.go
+++ b/pkg/rest/blockchainhandler/blockiterator_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockchainhandler
+
+import (
+	"testing"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSinceTimeIterator_Next(t *testing.T) {
+	const blockNum1 = uint64(1000)
+	const blockNum2 = uint64(1001)
+	const txnNum = uint64(1)
+
+	it := newBlockIterator(&cb.BlockchainInfo{Height: 1002}, blockNum1, txnNum)
+	require.NotNil(t, it)
+
+	desc, ok := it.Next()
+	require.True(t, ok)
+	require.NotNil(t, desc)
+	require.Equal(t, blockNum1, desc.BlockNum())
+	require.Equal(t, txnNum, desc.TxnNum())
+
+	desc, ok = it.Next()
+	require.True(t, ok)
+	require.NotNil(t, desc)
+	require.Equal(t, blockNum2, desc.BlockNum())
+	require.Equal(t, uint64(0), desc.TxnNum())
+
+	desc, ok = it.Next()
+	require.False(t, ok)
+	require.Nil(t, desc)
+}


### PR DESCRIPTION
The blockchain scanner now accepts a block iterator and a block scanner so that custom logic may be passed in.

closes #227

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>