### PR TITLE
chore: blockchain and dcas handlers underscores

### DIFF
--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -98,7 +98,7 @@ func TestServer_Start(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp, &createdDoc))
 		require.Equal(t, sampleID, createdDoc.Document["id"])
 
-		resp, err = httpGet(t, clientURL+samplePath+"/"+sampleID+"?max-size=1024")
+		resp, err = httpGet(t, clientURL+samplePath+"/"+sampleID+"?max_size=1024")
 		require.NoError(t, err)
 		require.NotEmpty(t, resp)
 
@@ -264,7 +264,7 @@ func (h *sampleResolveHandler) Path() string {
 
 // Params returns the context path
 func (h *sampleResolveHandler) Params() map[string]string {
-	return map[string]string{"max-size": "{max-size:[0-9]+}"}
+	return map[string]string{"max_size": "{max_size:[0-9]+}"}
 }
 
 // Method returns the HTTP method

--- a/pkg/rest/blockchainhandler/firstValidScanner.go
+++ b/pkg/rest/blockchainhandler/firstValidScanner.go
@@ -89,13 +89,13 @@ func (v *txnValidator) isValid() (bool, error) {
 	blockHash := protoutil.BlockHeaderHash(block.Header)
 	txnHash, err := base64.URLEncoding.DecodeString(v.desc.Transaction().TransactionTimeHash)
 	if err != nil {
-		logger.Debugf("[%s] Invalid base64 encoded TransactionTimeHash for TransactionTime: %s", v.channelID, v.desc.BlockNum(), err)
+		logger.Debugf("[%s] Invalid base64 encoded transaction_time_hash for transaction_time: %s", v.channelID, v.desc.BlockNum(), err)
 
 		return false, nil
 	}
 
 	if !bytes.Equal(blockHash, txnHash) {
-		logger.Debugf("[%s] TransactionTimeHash does not match the hash of the block header for block [%d]", v.channelID, v.desc.BlockNum())
+		logger.Debugf("[%s] transaction_time_hash does not match the hash of the block header for block [%d]", v.channelID, v.desc.BlockNum())
 
 		return false, nil
 	}

--- a/pkg/rest/blockchainhandler/firstValidScanner_test.go
+++ b/pkg/rest/blockchainhandler/firstValidScanner_test.go
@@ -163,7 +163,7 @@ func TestTxnValidator_Scan(t *testing.T) {
 		require.False(t, foundValid)
 	})
 
-	t.Run("Invalid AnchorString", func(t *testing.T) {
+	t.Run("Invalid anchor_string", func(t *testing.T) {
 		bb := mocks.NewBlockBuilder(channel1, blockNum1)
 		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor1))
 

--- a/pkg/rest/blockchainhandler/model.go
+++ b/pkg/rest/blockchainhandler/model.go
@@ -23,16 +23,16 @@ type TimeResponse struct {
 // TransactionsResponse contains a set of transactions and a boolean that indicates
 // whether or not there are more transactions available to return.
 type TransactionsResponse struct {
-	More         bool          `json:"moreTransactions"`
+	More         bool          `json:"more_transactions"`
 	Transactions []Transaction `json:"transactions"`
 }
 
 // Transaction contains data for a single Sidetree transaction
 type Transaction struct {
-	TransactionNumber   uint64 `json:"transactionNumber"`
-	TransactionTime     uint64 `json:"transactionTime"`
-	TransactionTimeHash string `json:"transactionTimeHash"`
-	AnchorString        string `json:"anchorString"`
+	TransactionNumber   uint64 `json:"transaction_number"`
+	TransactionTime     uint64 `json:"transaction_time"`
+	TransactionTimeHash string `json:"transaction_time_hash"`
+	AnchorString        string `json:"anchor_string"`
 }
 
 // ErrorResponse contains the error code for a failed response

--- a/pkg/rest/blockchainhandler/transactionshandler.go
+++ b/pkg/rest/blockchainhandler/transactionshandler.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	sinceParam    = "since"
-	timeHashParam = "transaction-time-hash"
+	timeHashParam = "transaction_time_hash"
 )
 
 type getTransactionsFunc func(*http.Request) (*TransactionsResponse, error)

--- a/pkg/rest/blockchainhandler/transactionshandler_test.go
+++ b/pkg/rest/blockchainhandler/transactionshandler_test.go
@@ -39,7 +39,7 @@ func TestNewTransactionsSinceHandler(t *testing.T) {
 	h := NewTransactionsSinceHandler(channel1, handlerCfg, bcProvider)
 	require.NotNil(t, h)
 
-	params := map[string]string{"since": "{since}", "transaction-time-hash": "{transaction-time-hash}"}
+	params := map[string]string{"since": "{since}", "transaction_time_hash": "{transaction_time_hash}"}
 
 	require.Equal(t, "/blockchain/transactions", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())

--- a/pkg/rest/dcashandler/model.go
+++ b/pkg/rest/dcashandler/model.go
@@ -16,7 +16,7 @@ const (
 	CodeInvalidHash ResultCode = "content_hash_invalid"
 	// CodeMaxSizeExceeded indicates that the resulting content exceeds the maximum size specified in the request
 	CodeMaxSizeExceeded ResultCode = "content_exceeds_maximum_allowed_size"
-	// CodeMaxSizeNotSpecified indicates that the max-size parameter was not specified in the request
+	// CodeMaxSizeNotSpecified indicates that the max_size parameter was not specified in the request
 	CodeMaxSizeNotSpecified ResultCode = "content_max_size_not_specified"
 	// CodeNotFound indicates that the content for the given hash was not found
 	CodeNotFound ResultCode = "content_not_found"

--- a/pkg/rest/dcashandler/retrievehandler.go
+++ b/pkg/rest/dcashandler/retrievehandler.go
@@ -22,7 +22,7 @@ var logger = flogging.MustGetLogger("sidetree_peer")
 
 const (
 	hashParam    = "hash"
-	maxSizeParam = "max-size"
+	maxSizeParam = "max_size"
 )
 
 // Retrieve manages file retrievals from the DCAS store
@@ -75,7 +75,7 @@ func (h *Retrieve) retrieve(rw http.ResponseWriter, req *http.Request) {
 
 	maxSize := getMaxSize(req)
 
-	logger.Debugf("[%s:%s:%s] Retrieving resp for hash [%s] with max-size %d", h.channelID, h.ChaincodeName, h.Collection, hash, maxSize)
+	logger.Debugf("[%s:%s:%s] Retrieving resp for hash [%s] with max_size %d", h.channelID, h.ChaincodeName, h.Collection, hash, maxSize)
 
 	rrw := newRetrieveWriter(rw)
 
@@ -150,7 +150,7 @@ func maxSizeFromString(str string) int {
 
 	size, err := strconv.Atoi(str)
 	if err != nil {
-		logger.Debugf("Invalid value for parameter [max-size]: %s", err)
+		logger.Debugf("Invalid value for parameter [max_size]: %s", err)
 
 		return 0
 	}

--- a/pkg/rest/dcashandler/retrievehandler_test.go
+++ b/pkg/rest/dcashandler/retrievehandler_test.go
@@ -93,7 +93,7 @@ func TestRetrieve_Handler(t *testing.T) {
 		require.Equal(t, CodeInvalidHash, rw.Body.String())
 	})
 
-	t.Run("No max-size -> Bad Request", func(t *testing.T) {
+	t.Run("No max_size -> Bad Request", func(t *testing.T) {
 		restoreParams := setParams(hash, "0")
 		defer restoreParams()
 
@@ -106,7 +106,7 @@ func TestRetrieve_Handler(t *testing.T) {
 		require.Equal(t, CodeMaxSizeNotSpecified, rw.Body.String())
 	})
 
-	t.Run("Invalid max-size -> Bad Request", func(t *testing.T) {
+	t.Run("Invalid max_size -> Bad Request", func(t *testing.T) {
 		restoreParams := setParams(hash, "xxx")
 		defer restoreParams()
 
@@ -154,7 +154,7 @@ func TestRetrieve_Handler(t *testing.T) {
 		require.Equal(t, content, rw.Body.Bytes())
 	})
 
-	t.Run("Max-size exceeded -> error", func(t *testing.T) {
+	t.Run("max_size exceeded -> error", func(t *testing.T) {
 		content := []byte{1, 2, 3, 4}
 
 		restoreParams := setParams(hash, "1")

--- a/test/bddtests/features/blockchain-handler.feature
+++ b/test/bddtests/features/blockchain-handler.feature
@@ -85,50 +85,50 @@ Feature:
 
     # The config setting for maxTransactionsInResponse is 10 so we should expect 10 transactions in the query for all transactions
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions"
-    And the JSON path "moreTransactions" of the boolean response equals "true"
-    And the JSON path "transactions.9.transactionTimeHash" of the response is not empty
-    And the JSON path "transactions.9.anchorString" of the response is not empty
-    And the JSON path "transactions.9.transactionTime" of the numeric response is saved to variable "time_9"
-    And the JSON path "transactions.9.transactionTimeHash" of the response is saved to variable "timeHash_9"
-    And the JSON path "transactions.9.transactionNumber" of the numeric response is saved to variable "txnNum_9"
-    And the JSON path "transactions.9.anchorString" of the response is saved to variable "anchor_9"
+    And the JSON path "more_transactions" of the boolean response equals "true"
+    And the JSON path "transactions.9.transaction_time_hash" of the response is not empty
+    And the JSON path "transactions.9.anchor_string" of the response is not empty
+    And the JSON path "transactions.9.transaction_time" of the numeric response is saved to variable "time_9"
+    And the JSON path "transactions.9.transaction_time_hash" of the response is saved to variable "timeHash_9"
+    And the JSON path "transactions.9.transaction_number" of the numeric response is saved to variable "txnNum_9"
+    And the JSON path "transactions.9.anchor_string" of the response is saved to variable "anchor_9"
 
     # Get more transactions from where we left off
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=${txnNum_9}&transaction-time-hash=${timeHash_9}"
-    And the JSON path "transactions.0.transactionTime" of the numeric response equals "${time_9}"
-    And the JSON path "transactions.0.transactionTimeHash" of the response equals "${timeHash_9}"
-    And the JSON path "transactions.0.transactionNumber" of the numeric response equals "${txnNum_9}"
-    And the JSON path "transactions.0.anchorString" of the response equals "${anchor_9}"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=${txnNum_9}&transaction_time_hash=${timeHash_9}"
+    And the JSON path "transactions.0.transaction_time" of the numeric response equals "${time_9}"
+    And the JSON path "transactions.0.transaction_time_hash" of the response equals "${timeHash_9}"
+    And the JSON path "transactions.0.transaction_number" of the numeric response equals "${txnNum_9}"
+    And the JSON path "transactions.0.anchor_string" of the response equals "${anchor_9}"
     And the JSON path "transactions" of the raw response is saved to variable "transactions"
 
     # Ensure that the anchor hash resolves to a valid value stored in DCAS
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${anchor_9}?max-size=1024"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${anchor_9}?max_size=1024"
     And the JSON path "batchFileHash" of the response is saved to variable "batchFileHash"
 
     # Ensure that the batch file hash resolves to a valid value stored in DCAS
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${batchFileHash}?max-size=8192"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${batchFileHash}?max_size=8192"
     And the JSON path "operations" of the array response is not empty
 
     # Invalid since
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=xxx&transaction-time-hash=${timeHash_9}" and the returned status code is 400
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=xxx&transaction_time_hash=${timeHash_9}" and the returned status code is 400
     And the JSON path "code" of the response equals "invalid_transaction_number_or_time_hash"
 
     # Invalid time hash
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=0&transaction-time-hash=xxx_xxx" and the returned status code is 400
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=0&transaction_time_hash=xxx_xxx" and the returned status code is 400
     And the JSON path "code" of the response equals "invalid_transaction_number_or_time_hash"
 
     # Hash not found
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=0&transaction-time-hash=AQIDBAUGBwgJCgsM" and the returned status code is 404
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=0&transaction_time_hash=AQIDBAUGBwgJCgsM" and the returned status code is 404
 
     # Valid transactions
     When an HTTP POST is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/firstValid" with content "${transactions}" of type "application/json"
-    Then the JSON path "transactionTime" of the numeric response equals "${time_9}"
-    And the JSON path "transactionTimeHash" of the response equals "${timeHash_9}"
-    And the JSON path "transactionNumber" of the numeric response equals "${txnNum_9}"
-    And the JSON path "anchorString" of the response equals "${anchor_9}"
+    Then the JSON path "transaction_time" of the numeric response equals "${time_9}"
+    And the JSON path "transaction_time_hash" of the response equals "${timeHash_9}"
+    And the JSON path "transaction_number" of the numeric response equals "${txnNum_9}"
+    And the JSON path "anchor_string" of the response equals "${anchor_9}"
 
     # Invalid transactions
-    Given variable "invalidTransactions" is assigned the JSON value '[{"transactionNumber":3,"transactionTime":10,"transactionTimeHash":"xsZhH8Wpg5_DNEIB3KN9ihtkVuBDLWWGJ2OlVWTIZBs=","anchorString":"invalid"}]'
+    Given variable "invalidTransactions" is assigned the JSON value '[{"transaction_number":3,"transaction_time":10,"transaction_time_hash":"xsZhH8Wpg5_DNEIB3KN9ihtkVuBDLWWGJ2OlVWTIZBs=","anchorString":"invalid"}]'
     When an HTTP POST is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/firstValid" with content "${invalidTransactions}" of type "application/json" and the returned status code is 404
 
   @invalid_blockchain_config

--- a/test/bddtests/features/dcas-handler.feature
+++ b/test/bddtests/features/dcas-handler.feature
@@ -41,8 +41,8 @@ Feature:
     When an HTTP POST is sent to "https://localhost:48326/sidetree/0.1.3/cas" with content from file "fixtures/testdata/schemas/geographical-location.schema.json"
     Then the JSON path "hash" of the response is saved to variable "contentHash"
 
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${contentHash}?max-size=1" and the returned status code is 400
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${contentHash}?max_size=1" and the returned status code is 400
     Then the response equals "content_exceeds_maximum_allowed_size"
 
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${contentHash}?max-size=1024"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${contentHash}?max_size=1024"
     And the JSON path "$id" of the response equals "https://example.com/geographical-location.schema.json"


### PR DESCRIPTION
updates the blockchain and dcas REST API to use underscores as
the word separator.

Signed-off-by: Troy Ronda <troy.ronda@securekey.com>