### PR TITLE
chore: Renamed resolution endpoint and base path of endpoints

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -367,8 +367,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b h1:M66/b+yyuzae5tiktRLN9XzoaQSsworNZ+xf7FFPUyg=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954 h1:2dhd8U3pZU2RKgSpNM6oclzYJPgmwRyMNyRE8QNigUU=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b h1:M66/b+yyuzae5tiktRLN9XzoaQSsworNZ+xf7FFPUyg=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954 h1:2dhd8U3pZU2RKgSpNM6oclzYJPgmwRyMNyRE8QNigUU=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -81,7 +81,7 @@ func TestServer_Start(t *testing.T) {
 		require.NoError(t, json.Unmarshal(resp, &createdDoc))
 		require.Equal(t, didID, createdDoc.Document["id"])
 
-		resp, err = httpGet(t, clientURL+didDocPath+"/"+didID)
+		resp, err = httpGet(t, clientURL+didDocPath+"/identifiers/"+didID)
 		require.NoError(t, err)
 		require.NotEmpty(t, resp)
 

--- a/pkg/peer/init_test.go
+++ b/pkg/peer/init_test.go
@@ -69,13 +69,13 @@ const (
 	peerNoneCfgJson      = `{}`
 
 	didTrustblocNamespace             = "did:bloc:trustbloc.dev"
-	didTrustblocBasePath              = "/trustbloc.dev"
+	didTrustblocBasePath              = "/trustbloc.dev/identifiers"
 	didTrustblocProtocol_V0_5_CfgJSON = `{"startingBlockchainTime":250000,"hashAlgorithmInMultihashCode":18,"MaxDeltaByteSize":20000,"maxOperationsPerBatch":200}`
 	didTrustblocCfgYaml               = `batchWriterTimeout: 1s`
 	didTrustblocCfgUpdateYaml         = `batchWriterTimeout: 5s`
 
 	didSidetreeNamespace             = "did:sidetree"
-	didSidetreeBasePath              = "/document"
+	didSidetreeBasePath              = "/document/identifiers"
 	didSidetreeCfgJSON               = `{"batchWriterTimeout":"5s"}`
 	didSidetreeProtocol_V0_4_CfgJSON = `{"startingBlockchainTime":200000,"hashAlgorithmInMultihashCode":18,"maxDeltaByteSize":2000,"maxOperationsPerBatch":10}`
 	didSidetreeProtocol_V0_5_CfgJSON = `{"startingBlockchainTime":500000,"hashAlgorithmInMultihashCode":18,"maxDeltaByteSize":10000,"maxOperationsPerBatch":100}`

--- a/test/bddtests/bddtests_test.go
+++ b/test/bddtests/bddtests_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/cucumber/godog"
+	"github.com/cucumber/godog/gherkin"
 	"github.com/spf13/viper"
 	"github.com/trustbloc/fabric-peer-test-common/bddtests"
 )
@@ -64,6 +65,11 @@ func TestMain(m *testing.M) {
 			}
 		})
 
+		s.BeforeScenario(func(i interface{}) {
+			if s, ok := i.(*gherkin.Scenario); ok {
+				logger.Infof("\n\n********** Running scenario: %s **********", s.Name)
+			}
+		})
 		FeatureContext(s)
 	}, godog.Options{
 		Tags:          tags,

--- a/test/bddtests/features/blockchain-handler.feature
+++ b/test/bddtests/features/blockchain-handler.feature
@@ -38,53 +38,53 @@ Feature:
 
   @blockchain_handler
   Scenario: Blockchain functions
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/version"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/version"
     Then the JSON path "name" of the response equals "Hyperledger Fabric"
     And the JSON path "version" of the response equals "2.0.0"
 
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/time"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/time"
     Then the JSON path "time" of the response is not empty
     And the JSON path "hash" of the response is not empty
     And the JSON path "time" of the response is saved to variable "time"
     And the JSON path "hash" of the response is saved to variable "hash"
 
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/time/${hash}"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/time/${hash}"
     Then the JSON path "hash" of the response equals "${hash}"
     And the JSON path "time" of the response equals "${time}"
 
     # Invalid hash - Bad Request (400)
-    Then an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/time/xxx_xxx" and the returned status code is 400
+    Then an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/time/xxx_xxx" and the returned status code is 400
 
     # Hash not found - Not Found (404)
-    Then an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/time/AQIDBAUGBwgJCgsM" and the returned status code is 404
+    Then an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/time/AQIDBAUGBwgJCgsM" and the returned status code is 404
 
     # Write a few Sidetree transactions. Scatter the requests across different endpoints to generate multiple
     # Sidetree transactions within the same block. The Orderer's batch timeout is set to 2s, so sleep 2s between
     # writes to guarantee that we generate a few blocks.
-    Then client sends request to "https://localhost:48326/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    Then client sends request to "https://localhost:48326/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     And check success response contains "#didDocumentHash"
-    And client sends request to "https://localhost:48327/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48328/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48327/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48328/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
 
     Then we wait 2 seconds
 
-    Then client sends request to "https://localhost:48427/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48428/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48326/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48327/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48328/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    Then client sends request to "https://localhost:48427/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48428/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48326/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48327/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48328/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
 
     Then we wait 2 seconds
 
-    Then client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48427/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
-    And client sends request to "https://localhost:48428/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    Then client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48427/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
+    And client sends request to "https://localhost:48428/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
 
     Then we wait 15 seconds
 
     # The config setting for maxTransactionsInResponse is 10 so we should expect 10 transactions in the query for all transactions
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/transactions"
     And the JSON path "more_transactions" of the boolean response equals "true"
     And the JSON path "transactions.9.transaction_time_hash" of the response is not empty
     And the JSON path "transactions.9.anchor_string" of the response is not empty
@@ -94,7 +94,7 @@ Feature:
     And the JSON path "transactions.9.anchor_string" of the response is saved to variable "anchor_9"
 
     # Get more transactions from where we left off
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=${txnNum_9}&transaction_time_hash=${timeHash_9}"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/transactions?since=${txnNum_9}&transaction_time_hash=${timeHash_9}"
     And the JSON path "transactions.0.transaction_time" of the numeric response equals "${time_9}"
     And the JSON path "transactions.0.transaction_time_hash" of the response equals "${timeHash_9}"
     And the JSON path "transactions.0.transaction_number" of the numeric response equals "${txnNum_9}"
@@ -102,26 +102,26 @@ Feature:
     And the JSON path "transactions" of the raw response is saved to variable "transactions"
 
     # Ensure that the anchor hash resolves to a valid value stored in DCAS
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${anchor_9}?max_size=1024"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${anchor_9}?max_size=1024"
     And the JSON path "batchFileHash" of the response is saved to variable "batchFileHash"
 
     # Ensure that the batch file hash resolves to a valid value stored in DCAS
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${batchFileHash}?max_size=8192"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${batchFileHash}?max_size=8192"
     And the JSON path "operations" of the array response is not empty
 
     # Invalid since
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=xxx&transaction_time_hash=${timeHash_9}" and the returned status code is 400
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/transactions?since=xxx&transaction_time_hash=${timeHash_9}" and the returned status code is 400
     And the JSON path "code" of the response equals "invalid_transaction_number_or_time_hash"
 
     # Invalid time hash
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=0&transaction_time_hash=xxx_xxx" and the returned status code is 400
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/transactions?since=0&transaction_time_hash=xxx_xxx" and the returned status code is 400
     And the JSON path "code" of the response equals "invalid_transaction_number_or_time_hash"
 
     # Hash not found
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/transactions?since=0&transaction_time_hash=AQIDBAUGBwgJCgsM" and the returned status code is 404
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/transactions?since=0&transaction_time_hash=AQIDBAUGBwgJCgsM" and the returned status code is 404
 
     # Valid transactions
-    When an HTTP POST is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/firstValid" with content "${transactions}" of type "application/json"
+    When an HTTP POST is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/firstValid" with content "${transactions}" of type "application/json"
     Then the JSON path "transaction_time" of the numeric response equals "${time_9}"
     And the JSON path "transaction_time_hash" of the response equals "${timeHash_9}"
     And the JSON path "transaction_number" of the numeric response equals "${txnNum_9}"
@@ -129,9 +129,9 @@ Feature:
 
     # Invalid transactions
     Given variable "invalidTransactions" is assigned the JSON value '[{"transaction_number":3,"transaction_time":10,"transaction_time_hash":"xsZhH8Wpg5_DNEIB3KN9ihtkVuBDLWWGJ2OlVWTIZBs=","anchorString":"invalid"}]'
-    When an HTTP POST is sent to "https://localhost:48326/sidetree/0.1.3/blockchain/firstValid" with content "${invalidTransactions}" of type "application/json" and the returned status code is 404
+    When an HTTP POST is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/firstValid" with content "${invalidTransactions}" of type "application/json" and the returned status code is 404
 
   @invalid_blockchain_config
   Scenario: Invalid configuration
     Given fabric-cli context "mychannel" is used
-    When fabric-cli is executed with args "ledgerconfig update --configfile ./fixtures/config/fabric/invalid-blockchainhandler-config.json --noprompt" then the error response should contain "component name must be set to the base path [/sidetree/0.1.3/blockchain]"
+    When fabric-cli is executed with args "ledgerconfig update --configfile ./fixtures/config/fabric/invalid-blockchainhandler-config.json --noprompt" then the error response should contain "component name must be set to the base path [/sidetree/0.0.1/blockchain]"

--- a/test/bddtests/features/dcas-handler.feature
+++ b/test/bddtests/features/dcas-handler.feature
@@ -34,15 +34,15 @@ Feature:
 
   @upload_and_retrieve_content
   Scenario: upload files to DCAS
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/version"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/version"
     Then the JSON path "name" of the response equals "cas"
     And the JSON path "version" of the response equals "0.1.3"
 
-    When an HTTP POST is sent to "https://localhost:48326/sidetree/0.1.3/cas" with content from file "fixtures/testdata/schemas/geographical-location.schema.json"
+    When an HTTP POST is sent to "https://localhost:48326/sidetree/0.0.1/cas" with content from file "fixtures/testdata/schemas/geographical-location.schema.json"
     Then the JSON path "hash" of the response is saved to variable "contentHash"
 
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${contentHash}?max_size=1" and the returned status code is 400
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${contentHash}?max_size=1" and the returned status code is 400
     Then the response equals "content_exceeds_maximum_allowed_size"
 
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.1.3/cas/${contentHash}?max_size=1024"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${contentHash}?max_size=1024"
     And the JSON path "$id" of the response equals "https://example.com/geographical-location.schema.json"

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -35,8 +35,8 @@ Feature:
     And we wait 15 seconds
 
     # Configure the following Sidetree namespaces on channel 'mychannel'
-    # - did:bloc:sidetree       - Path: /sidetree/0.1.3/sidetree, /sidetree/0.1.3/sidetree/operations
-    # - did:bloc:trustbloc.dev  - Path: /trustbloc.dev, /trustbloc.dev/operations
+    # - did:bloc:sidetree       - Path: /sidetree/0.0.1/identifiers, /sidetree/0.0.1/operations
+    # - did:bloc:trustbloc.dev  - Path: /trustbloc.dev/identifiers, /trustbloc.dev/operations
     Then fabric-cli context "mychannel" is used
     And fabric-cli is executed with args "ledgerconfig update --configfile ./fixtures/config/fabric/mychannel-consortium-config.json --noprompt"
     And fabric-cli is executed with args "ledgerconfig update --configfile ./fixtures/config/fabric/mychannel-org1-config.json --noprompt"
@@ -57,120 +57,120 @@ Feature:
 
   @create_did_doc
   Scenario: create valid did doc
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48327/sidetree/0.1.3/sidetree" to resolve DID document with initial value
+    When client sends request to "https://localhost:48327/sidetree/0.0.1/identifiers" to resolve DID document with initial value
     Then check success response contains "#didDocumentHash"
 
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48327/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48327/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
     When client sends request to "https://localhost:48426/trustbloc.dev/operations" to create DID document in namespace "did:bloc:trustbloc.dev"
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48327/trustbloc.dev" to resolve DID document with initial value
+    When client sends request to "https://localhost:48327/trustbloc.dev/identifiers" to resolve DID document with initial value
     Then check success response contains "#didDocumentHash"
 
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48327/trustbloc.dev" to resolve DID document
+    When client sends request to "https://localhost:48327/trustbloc.dev/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
     When client sends request to "https://localhost:48426/yourdomain.com/operations" to create DID document in namespace "did:bloc:yourdomain.com"
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48327/yourdomain.com" to resolve DID document with initial value
+    When client sends request to "https://localhost:48327/yourdomain.com/identifiers" to resolve DID document with initial value
     Then check success response contains "#didDocumentHash"
 
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48327/yourdomain.com" to resolve DID document
+    When client sends request to "https://localhost:48327/yourdomain.com/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
   @create_deactivate_did_doc
   Scenario: create and deactivate valid did doc
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to deactivate DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to deactivate DID document
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check error response contains "document is no longer available"
 
   @create_recover_did_doc
   Scenario: create and recover did doc
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to recover DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to recover DID document
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "recoveryKey"
 
   @create_update_did_doc
   Scenario: create and update valid did doc
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to update DID document path "/publicKey/0/type" with value "updatedValue"
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to update DID document path "/publicKey/0/type" with value "updatedValue"
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "updatedValue"
 
   @create_add_remove_public_key
   Scenario: add and remove public keys
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to add public key with ID "newKey" to DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to add public key with ID "newKey" to DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "newKey"
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to remove public key with ID "newKey" from DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to remove public key with ID "newKey" from DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response does NOT contain "newKey"
 
   @create_add_remove_services
   Scenario: add and remove service endpoints
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
     And we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to add service endpoint with ID "newService" to DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to add service endpoint with ID "newService" to DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "newService"
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree/operations" to remove service endpoint with ID "newService" from DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/operations" to remove service endpoint with ID "newService" from DID document
     Then we wait 10 seconds
 
-    When client sends request to "https://localhost:48426/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response does NOT contain "newService"

--- a/test/bddtests/features/e2e.feature
+++ b/test/bddtests/features/e2e.feature
@@ -11,8 +11,16 @@ Feature:
   @sanity_s1
   Scenario: sanity
     Given the channel "mychannel" is created and all peers have joined
+
+    # Give the peers some time to gossip their new channel membership
+    And we wait 10 seconds
+
     And "test" chaincode "e2e_cc" is installed from path "github.com/trustbloc/sidetree-fabric/test/chaincode/e2e_cc" to all peers
     And "test" chaincode "e2e_cc" is instantiated from path "github.com/trustbloc/sidetree-fabric/test/chaincode/e2e_cc" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
+
+    # Give the peers some time to gossip their installed chaincode
+    And we wait 10 seconds
+
     And chaincode "e2e_cc" is warmed up on all peers on the "mychannel" channel
 
     # Test transactions

--- a/test/bddtests/features/sidetreetxn.feature
+++ b/test/bddtests/features/sidetreetxn.feature
@@ -54,7 +54,7 @@ Feature:
     And we wait 2 seconds
 
     # Send the operation to peer0.org1.
-    When client sends request to "https://localhost:48326/sidetree/0.1.3/sidetree/operations" to create DID document in namespace "did:sidetree"
+    When client sends request to "https://localhost:48326/sidetree/0.0.1/operations" to create DID document in namespace "did:sidetree"
     Then check success response contains "#didDocumentHash"
 
     # Stop peer0.org1 after sending it an operation. The operation should have
@@ -74,7 +74,7 @@ Feature:
 
     # Retrieve the document from another peer since, by this time, the operation should have
     # been processed and distributed to all peers.
-    When client sends request to "https://localhost:48427/sidetree/0.1.3/sidetree" to resolve DID document
+    When client sends request to "https://localhost:48427/sidetree/0.0.1/identifiers" to resolve DID document
     Then check success response contains "#didDocumentHash"
 
   @invalid_config_update

--- a/test/bddtests/fixtures/config/fabric/invalid-blockchainhandler-config.json
+++ b/test/bddtests/fixtures/config/fabric/invalid-blockchainhandler-config.json
@@ -9,9 +9,9 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/invalid",
+              "Name": "/sidetree/0.0.1/invalid",
               "Version": "0.1.3",
-              "Config": "{\"BasePath\":\"/sidetree/0.1.3/blockchain\"}",
+              "Config": "{\"BasePath\":\"/sidetree/0.0.1/blockchain\"}",
               "Format": "json"
             }
           ]

--- a/test/bddtests/fixtures/config/fabric/mychannel-blockchainhandler-config.yaml
+++ b/test/bddtests/fixtures/config/fabric/mychannel-blockchainhandler-config.yaml
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-basePath: /sidetree/0.1.3/blockchain
+basePath: /sidetree/0.0.1/blockchain
 maxTransactionsInResponse: 10

--- a/test/bddtests/fixtures/config/fabric/mychannel-dcashandler-config.yaml
+++ b/test/bddtests/fixtures/config/fabric/mychannel-dcashandler-config.yaml
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-basePath: /sidetree/0.1.3/cas
+basePath: /sidetree/0.0.1/cas
 chaincodeName: sidetreetxn
 collection: dcas

--- a/test/bddtests/fixtures/config/fabric/mychannel-org1-config.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-org1-config.json
@@ -51,7 +51,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -63,7 +63,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/blockchain",
+              "Name": "/sidetree/0.0.1/blockchain",
               "Version": "0.1.3",
               "Config": "file://./mychannel-blockchainhandler-config.yaml",
               "Format": "yaml"
@@ -122,7 +122,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -134,7 +134,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/blockchain",
+              "Name": "/sidetree/0.0.1/blockchain",
               "Version": "0.1.3",
               "Config": "file://./mychannel-blockchainhandler-config.yaml",
               "Format": "yaml"
@@ -193,7 +193,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -205,7 +205,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/blockchain",
+              "Name": "/sidetree/0.0.1/blockchain",
               "Version": "0.1.3",
               "Config": "file://./mychannel-blockchainhandler-config.yaml",
               "Format": "yaml"

--- a/test/bddtests/fixtures/config/fabric/mychannel-org1-dcashandler-config.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-org1-dcashandler-config.json
@@ -9,7 +9,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -26,7 +26,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -43,7 +43,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"

--- a/test/bddtests/fixtures/config/fabric/mychannel-org2-config.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-org2-config.json
@@ -51,7 +51,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -63,7 +63,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/blockchain",
+              "Name": "/sidetree/0.0.1/blockchain",
               "Version": "0.1.3",
               "Config": "file://./mychannel-blockchainhandler-config.yaml",
               "Format": "yaml"
@@ -122,7 +122,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -134,7 +134,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/blockchain",
+              "Name": "/sidetree/0.0.1/blockchain",
               "Version": "0.1.3",
               "Config": "file://./mychannel-blockchainhandler-config.yaml",
               "Format": "yaml"
@@ -193,7 +193,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -205,7 +205,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/blockchain",
+              "Name": "/sidetree/0.0.1/blockchain",
               "Version": "0.1.3",
               "Config": "file://./mychannel-blockchainhandler-config.yaml",
               "Format": "yaml"

--- a/test/bddtests/fixtures/config/fabric/mychannel-org2-dcashandler-config.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-org2-dcashandler-config.json
@@ -9,7 +9,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -26,7 +26,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"
@@ -43,7 +43,7 @@
           "Version": "1",
           "Components": [
             {
-              "Name": "/sidetree/0.1.3/cas",
+              "Name": "/sidetree/0.0.1/cas",
               "Version": "0.1.3",
               "Config": "file://./mychannel-dcashandler-config.yaml",
               "Format": "yaml"

--- a/test/bddtests/fixtures/config/fabric/mychannel-sidetree-config-org1.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-sidetree-config-org1.json
@@ -6,7 +6,7 @@
   "Namespaces": [
     {
       "Namespace": "did:sidetree",
-      "BasePath": "/sidetree/0.1.3/sidetree"
+      "BasePath": "/sidetree/0.0.1"
     },
     {
       "Namespace": "did:bloc:trustbloc.dev",

--- a/test/bddtests/fixtures/config/fabric/mychannel-sidetree-config-org2.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-sidetree-config-org2.json
@@ -6,7 +6,7 @@
   "Namespaces": [
     {
       "Namespace": "did:sidetree",
-      "BasePath": "/sidetree/0.1.3/sidetree"
+      "BasePath": "/sidetree/0.0.1"
     },
     {
       "Namespace": "did:bloc:trustbloc.dev",

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200423201846-d594135fea49
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -209,8 +209,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200423201846-d594135fea4
 github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200423201846-d594135fea49/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b h1:M66/b+yyuzae5tiktRLN9XzoaQSsworNZ+xf7FFPUyg=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424131357-a081410c751b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954 h1:2dhd8U3pZU2RKgSpNM6oclzYJPgmwRyMNyRE8QNigUU=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200424141236-d4a225751954/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Renamed the resolutions endpoint to /identifiers and the base path of all Sidetree endpoints was changed to /sidetree/0.0.1.

closes #240
closes #241

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>