### PR TITLE
chore: Update sidetree-core - remove replace patch

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -367,8 +367,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670 h1:i1rUTcU9IokHsf4DMftvdCYmD8lOKjmsSDVWD6FcgO8=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7 h1:GGcYQvkFHASFCXB/TfI4lR9H4S8WiPhwBztKdy4Fxlc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670 h1:i1rUTcU9IokHsf4DMftvdCYmD8lOKjmsSDVWD6FcgO8=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7 h1:GGcYQvkFHASFCXB/TfI4lR9H4S8WiPhwBztKdy4Fxlc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/rest/filehandler/validator_test.go
+++ b/pkg/rest/filehandler/validator_test.go
@@ -235,12 +235,12 @@ func TestUnmarshalUpdateOperation(t *testing.T) {
 
 func TestValidatePatch(t *testing.T) {
 	t.Run("not ietf-json-patch", func(t *testing.T) {
-		p, err := patch.NewReplacePatch("{}")
+		p, err := patch.NewAddPublicKeysPatch("{}")
 		require.NoError(t, err)
 
 		err = validatePatch(p)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "patch action 'replace' not supported")
+		require.Contains(t, err.Error(), "patch action 'add-public-keys' not supported")
 	})
 	t.Run("missing patch value", func(t *testing.T) {
 		p, err := patch.NewJSONPatch(`[{"op": "add", "path": "path", "value": "value"}]`)

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -149,7 +149,7 @@ func (d *DIDSideSteps) resolveDIDDocumentWithInitialValue(url string) error {
 		return err
 	}
 
-	initialState := d.createRequest.Delta + "." + d.createRequest.SuffixData
+	initialState := d.createRequest.SuffixData + "." + d.createRequest.Delta
 
 	method, err := getMethod(d.reqNamespace)
 	if err != nil {

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200423201846-d594135fea49
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -209,8 +209,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200423201846-d594135fea4
 github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200423201846-d594135fea49/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670 h1:i1rUTcU9IokHsf4DMftvdCYmD8lOKjmsSDVWD6FcgO8=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200426220923-eb5e95cdb670/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7 h1:GGcYQvkFHASFCXB/TfI4lR9H4S8WiPhwBztKdy4Fxlc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200428141709-55b29d7982a7/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Sidetree core has been updated:
- remove 'replace' patch
- init state params order

Closes #253

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>