### PR TITLE
feat: Added blockchain/info REST handler

### DIFF
--- a/pkg/peer/config/blockchainhandlervalidator.go
+++ b/pkg/peer/config/blockchainhandlervalidator.go
@@ -69,7 +69,7 @@ func (v *blockchainHandlerValidator) validateBlockchainHandler(cfg blockchainhan
 	}
 
 	if cfg.MaxTransactionsInResponse == 0 {
-		logger.Warn("field 'MaxTransactionsInResponse' is not set for %s. Will use default value.", kv.Key)
+		logger.Warnf("field 'MaxTransactionsInResponse' is not set for %s. Will use default value.", kv.Key)
 	}
 
 	return nil

--- a/pkg/peer/sidetreesvc/channelctrl.go
+++ b/pkg/peer/sidetreesvc/channelctrl.go
@@ -475,20 +475,15 @@ func (c *channelController) loadBlockchainHandlers(handlerCfg []blockchainhandle
 func (c *channelController) loadBlockchainHandler(cfg blockchainhandler.Config) []common.HTTPHandler {
 	var handlers []common.HTTPHandler
 
-	logger.Debugf("Adding blockchain time handlers for base path [%s]", cfg.BasePath)
+	logger.Debugf("Adding blockchain handlers for base path [%s]", cfg.BasePath)
 
 	handlers = append(handlers, blockchainhandler.NewTimeHandler(c.channelID, cfg, c.BlockchainProvider))
 	handlers = append(handlers, blockchainhandler.NewTimeByHashHandler(c.channelID, cfg, c.BlockchainProvider))
-
-	logger.Debugf("Adding blockchain version handler for base path [%s]", cfg.BasePath)
-
 	handlers = append(handlers, blockchainhandler.NewVersionHandler(c.channelID, cfg))
-
-	logger.Debugf("Adding blockchain transactions handlers for base path [%s]", cfg.BasePath)
-
 	handlers = append(handlers, blockchainhandler.NewTransactionsSinceHandler(c.channelID, cfg, c.BlockchainProvider))
 	handlers = append(handlers, blockchainhandler.NewTransactionsHandler(c.channelID, cfg, c.BlockchainProvider))
 	handlers = append(handlers, blockchainhandler.NewFirstValidHandler(c.channelID, cfg, c.BlockchainProvider))
+	handlers = append(handlers, blockchainhandler.NewInfoHandler(c.channelID, cfg, c.BlockchainProvider))
 
 	return handlers
 }

--- a/pkg/peer/sidetreesvc/channelctrl_test.go
+++ b/pkg/peer/sidetreesvc/channelctrl_test.go
@@ -331,7 +331,7 @@ func TestChannelController_LoadBlockchainHandlers(t *testing.T) {
 
 	stConfigService.LoadBlockchainHandlersReturns(blockchainHandlers, nil)
 	require.NoError(t, c.load())
-	require.Len(t, c.RESTHandlers(), 6)
+	require.Len(t, c.RESTHandlers(), 7)
 }
 
 func setRoles(roles ...extroles.Role) func() {

--- a/pkg/rest/blockchainhandler/blockchaininfohandler.go
+++ b/pkg/rest/blockchainhandler/blockchaininfohandler.go
@@ -1,0 +1,68 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockchainhandler
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+	"github.com/trustbloc/sidetree-fabric/pkg/httpserver"
+)
+
+// Info retrieves basic information about the blockchain
+type Info struct {
+	*handler
+}
+
+// NewInfoHandler returns a new blockchain info handler
+func NewInfoHandler(channelID string, cfg Config, blockchainProvider blockchainClientProvider) *Info {
+	return &Info{
+		handler: newHandler(
+			channelID, cfg,
+			fmt.Sprintf("%s/info", cfg.BasePath),
+			http.MethodGet,
+			blockchainProvider,
+		),
+	}
+}
+
+// Handler returns the request handler
+func (h *Info) Handler() common.HTTPRequestHandler {
+	return h.blockchainInfo
+}
+
+func (h *Info) blockchainInfo(w http.ResponseWriter, _ *http.Request) {
+	logger.Info("Handling blockchainInfo ...")
+
+	rw := httpserver.NewResponseWriter(w)
+
+	bcInfo, err := h.getBlockchainInfo()
+	if err != nil {
+		rw.WriteError(err)
+		return
+	}
+
+	resp := &InfoResponse{
+		CurrentTime:      bcInfo.Height - 1,
+		CurrentTimeHash:  base64.URLEncoding.EncodeToString(bcInfo.CurrentBlockHash),
+		PreviousTimeHash: base64.URLEncoding.EncodeToString(bcInfo.PreviousBlockHash),
+	}
+
+	infoBytes, err := h.jsonMarshal(resp)
+	if err != nil {
+		logger.Errorf("Unable to marshal blockchain info: %s", err)
+
+		rw.WriteError(httpserver.ServerError)
+		return
+	}
+
+	logger.Debugf("[%s] ... returning blockchain info: %s", h.channelID, infoBytes)
+
+	rw.Write(http.StatusOK, infoBytes, httpserver.ContentTypeJSON)
+}

--- a/pkg/rest/blockchainhandler/blockchaininfohandler_test.go
+++ b/pkg/rest/blockchainhandler/blockchaininfohandler_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockchainhandler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trustbloc/sidetree-fabric/pkg/httpserver"
+	"github.com/trustbloc/sidetree-fabric/pkg/observer/mocks"
+)
+
+func TestNewInfoHandler(t *testing.T) {
+	bcProvider := &mocks.BlockchainClientProvider{}
+
+	h := NewInfoHandler(channel1, handlerCfg, bcProvider)
+	require.NotNil(t, h)
+
+	require.Equal(t, "/blockchain/info", h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+}
+
+func TestInfo_Latest(t *testing.T) {
+	bcInfo := &common.BlockchainInfo{
+		Height:           1000,
+		CurrentBlockHash: []byte{1, 2, 3, 4},
+	}
+
+	bcProvider := &mocks.BlockchainClientProvider{}
+
+	t.Run("Success", func(t *testing.T) {
+		bcClient := &mocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewInfoHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/blockchain/info", nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		resp := &InfoResponse{}
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), resp))
+		require.Equal(t, bcInfo.Height-1, resp.CurrentTime)
+		require.Equal(t, base64.URLEncoding.EncodeToString(bcInfo.CurrentBlockHash), resp.CurrentTimeHash)
+		require.Equal(t, base64.URLEncoding.EncodeToString(bcInfo.PreviousBlockHash), resp.PreviousTimeHash)
+	})
+
+	t.Run("Marshal error -> Server Error", func(t *testing.T) {
+		bcClient := &mocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewInfoHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+		h.jsonMarshal = func(v interface{}) ([]byte, error) { return nil, errors.New("injected marshal error") }
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/blockchain/info", nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+
+	t.Run("Blockchain provider error -> Server Error", func(t *testing.T) {
+		bcProvider.ForChannelReturns(nil, errors.New("injected blockchain provider error"))
+
+		h := NewInfoHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/blockchain/info", nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+
+	t.Run("Blockchain client error -> Server Error", func(t *testing.T) {
+		bcClient := &mocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(nil, errors.New("injected blockchain client error"))
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewInfoHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/blockchain/info", nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+}

--- a/pkg/rest/blockchainhandler/config.go
+++ b/pkg/rest/blockchainhandler/config.go
@@ -6,7 +6,7 @@ SPDX-License-Identifier: Apache-2.0
 
 package blockchainhandler
 
-// Config defines the configuration for a DCAS handler
+// Config defines the configuration for a blockchain handler
 type Config struct {
 	// BasePath is the base context path of the REST endpoint
 	BasePath string

--- a/pkg/rest/blockchainhandler/handler.go
+++ b/pkg/rest/blockchainhandler/handler.go
@@ -1,0 +1,122 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockchainhandler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	bcclient "github.com/trustbloc/sidetree-fabric/pkg/client"
+	"github.com/trustbloc/sidetree-fabric/pkg/httpserver"
+)
+
+type handler struct {
+	Config
+	path               string
+	method             string
+	params             map[string]string
+	channelID          string
+	blockchainProvider blockchainClientProvider
+	jsonMarshal        func(v interface{}) ([]byte, error)
+}
+
+func newHandler(channelID string, cfg Config, path string, method string, blockchainProvider blockchainClientProvider, params ...string) *handler {
+	return &handler{
+		Config:             cfg,
+		channelID:          channelID,
+		path:               path,
+		method:             method,
+		params:             paramsBuilder(params).build(),
+		blockchainProvider: blockchainProvider,
+		jsonMarshal:        json.Marshal,
+	}
+}
+
+// Path returns the context path
+func (h *handler) Path() string {
+	return h.path
+}
+
+// Params returns the accepted parameters
+func (h *handler) Params() map[string]string {
+	return h.params
+}
+
+// Method returns the HTTP method
+func (h *handler) Method() string {
+	return h.method
+}
+
+func (h *handler) blockchainClient() (bcclient.Blockchain, error) {
+	bcClient, err := h.blockchainProvider.ForChannel(h.channelID)
+	if err != nil {
+		logger.Errorf("[%s] Failed to get blockchain client: %s", h.channelID, err)
+
+		return nil, httpserver.ServerError
+	}
+
+	return bcClient, nil
+}
+
+func (h *handler) getBlockByHash(strHash string) (*cb.Block, error) {
+	hash, err := base64.URLEncoding.DecodeString(strHash)
+	if err != nil {
+		logger.Debugf("Invalid base64 encoded hash [%s]: %s", strHash, err)
+
+		return nil, httpserver.NewError(http.StatusBadRequest, httpserver.StatusBadRequest)
+	}
+
+	bcClient, err := h.blockchainClient()
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := bcClient.GetBlockByHash(hash)
+	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, httpserver.NotFoundError
+		}
+
+		logger.Errorf("Failed to get block for hash [%s]: %s", strHash, err)
+
+		return nil, httpserver.ServerError
+	}
+
+	return block, nil
+}
+
+func (h *handler) getBlockchainInfo() (*cb.BlockchainInfo, error) {
+	bcClient, err := h.blockchainClient()
+	if err != nil {
+		return nil, err
+	}
+
+	bcInfo, err := bcClient.GetBlockchainInfo()
+	if err != nil {
+		logger.Errorf("[%s] Failed to get blockchain info: %s", h.channelID, err)
+
+		return nil, httpserver.ServerError
+	}
+
+	return bcInfo, nil
+}
+
+type paramsBuilder []string
+
+func (p paramsBuilder) build() map[string]string {
+	m := make(map[string]string)
+
+	for _, p := range p {
+		m[p] = fmt.Sprintf("{%s}", p)
+	}
+
+	return m
+}

--- a/pkg/rest/blockchainhandler/model.go
+++ b/pkg/rest/blockchainhandler/model.go
@@ -39,3 +39,15 @@ type Transaction struct {
 type ErrorResponse struct {
 	Code string `json:"code"`
 }
+
+// InfoResponse contains basic information about the blockchain.
+type InfoResponse struct {
+	// CurrentTime is the time (block number) of the current (latest) block in the chain.
+	CurrentTime uint64 `json:"current_time"`
+	// CurrentTimeHash is the base64 URL-encoded hash of the current (latest) block's header.
+	// (This value may be used to retrieve the latest block by hash.)
+	CurrentTimeHash string `json:"current_time_hash"`
+	// PreviousTimeHash is the base64 URL-encoded hash of the previous block's header.
+	// (This value may be used to retrieve the previous block by hash.)
+	PreviousTimeHash string `json:"previous_time_hash"`
+}

--- a/test/bddtests/features/blockchain-handler.feature
+++ b/test/bddtests/features/blockchain-handler.feature
@@ -131,6 +131,11 @@ Feature:
     Given variable "invalidTransactions" is assigned the JSON value '[{"transaction_number":3,"transaction_time":10,"transaction_time_hash":"xsZhH8Wpg5_DNEIB3KN9ihtkVuBDLWWGJ2OlVWTIZBs=","anchorString":"invalid"}]'
     When an HTTP POST is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/firstValid" with content "${invalidTransactions}" of type "application/json" and the returned status code is 404
 
+    # Blockchain info
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/info"
+    And the JSON path "current_time_hash" of the response is not empty
+    And the JSON path "previous_time_hash" of the response is not empty
+
   @invalid_blockchain_config
   Scenario: Invalid configuration
     Given fabric-cli context "mychannel" is used


### PR DESCRIPTION
Added a REST endpoint that retrieves basic information about the blockchain, including current block time and hash, and previous block hash.
Also, moved common functions to a base handler struct.

closes #255

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>