### PR TITLE
feat: Added blockchain/configblock REST endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/evanphx/json-patch v4.1.0+incompatible
+	github.com/golang/protobuf v1.3.2
 	github.com/gorilla/mux v1.7.3
 	github.com/hyperledger/fabric v2.0.0+incompatible
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20200128192331-2d899240a7ed

--- a/pkg/peer/sidetreesvc/channelctrl.go
+++ b/pkg/peer/sidetreesvc/channelctrl.go
@@ -488,6 +488,10 @@ func (c *channelController) loadBlockchainHandler(cfg blockchainhandler.Config) 
 	handlers = append(handlers, blockchainhandler.NewBlockByHashHandler(c.channelID, cfg, c.BlockchainProvider))
 	handlers = append(handlers, blockchainhandler.NewBlocksFromNumHandlerWithEncoding(c.channelID, cfg, c.BlockchainProvider))
 	handlers = append(handlers, blockchainhandler.NewBlocksFromNumHandler(c.channelID, cfg, c.BlockchainProvider))
+	handlers = append(handlers, blockchainhandler.NewConfigBlockHandlerWithEncoding(c.channelID, cfg, c.BlockchainProvider))
+	handlers = append(handlers, blockchainhandler.NewConfigBlockHandler(c.channelID, cfg, c.BlockchainProvider))
+	handlers = append(handlers, blockchainhandler.NewConfigBlockByHashHandlerWithEncoding(c.channelID, cfg, c.BlockchainProvider))
+	handlers = append(handlers, blockchainhandler.NewConfigBlockByHashHandler(c.channelID, cfg, c.BlockchainProvider))
 
 	return handlers
 }

--- a/pkg/peer/sidetreesvc/channelctrl_test.go
+++ b/pkg/peer/sidetreesvc/channelctrl_test.go
@@ -331,7 +331,7 @@ func TestChannelController_LoadBlockchainHandlers(t *testing.T) {
 
 	stConfigService.LoadBlockchainHandlersReturns(blockchainHandlers, nil)
 	require.NoError(t, c.load())
-	require.Len(t, c.RESTHandlers(), 11)
+	require.Len(t, c.RESTHandlers(), 15)
 }
 
 func setRoles(roles ...extroles.Role) func() {

--- a/pkg/rest/blockchainhandler/blockchaininfohandler.go
+++ b/pkg/rest/blockchainhandler/blockchaininfohandler.go
@@ -38,8 +38,6 @@ func (h *Info) Handler() common.HTTPRequestHandler {
 }
 
 func (h *Info) blockchainInfo(w http.ResponseWriter, _ *http.Request) {
-	logger.Info("Handling blockchainInfo ...")
-
 	rw := httpserver.NewResponseWriter(w)
 
 	bcInfo, err := h.getBlockchainInfo()

--- a/pkg/rest/blockchainhandler/blockshandler_test.go
+++ b/pkg/rest/blockchainhandler/blockshandler_test.go
@@ -407,14 +407,14 @@ func TestBlocks_ByHash(t *testing.T) {
 	})
 
 	t.Run("Missing hash param -> BadRequest", func(t *testing.T) {
-		restoreParams := setBlocksFromParams("", "1")
+		restoreParams := setBlocksByHashParams("")
 		defer restoreParams()
 
 		testInvalidParams(t, NewBlockByHashHandler, InvalidTimeHash)
 	})
 
 	t.Run("Invalid hash param -> BadRequest", func(t *testing.T) {
-		restoreParams := setBlocksFromParams("xxx", "1")
+		restoreParams := setBlocksByHashParams("xxx")
 		defer restoreParams()
 
 		testInvalidParams(t, NewBlockByHashHandler, InvalidTimeHash)

--- a/pkg/rest/blockchainhandler/configblockhandler.go
+++ b/pkg/rest/blockchainhandler/configblockhandler.go
@@ -1,0 +1,183 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockchainhandler
+
+import (
+	"fmt"
+	"net/http"
+
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
+	"github.com/trustbloc/sidetree-fabric/pkg/httpserver"
+)
+
+type getConfigBlockFunc func(req *http.Request) (Block, error)
+
+// ConfigBlock retrieves basic information about the Fabric blockchain
+type ConfigBlock struct {
+	*handler
+	getConfigBlock getConfigBlockFunc
+}
+
+// NewConfigBlockHandler returns a new config block handler which returns the latest config block
+func NewConfigBlockHandler(channelID string, cfg Config, blockchainProvider blockchainClientProvider) *ConfigBlock {
+	h := newConfigBlock(
+		channelID, cfg,
+		fmt.Sprintf("%s/configblock", cfg.BasePath),
+		blockchainProvider,
+	)
+
+	h.getConfigBlock = h.getLatestConfigBlock
+
+	return h
+}
+
+// NewConfigBlockHandlerWithEncoding returns a new config block handler which returns the latest config block
+func NewConfigBlockHandlerWithEncoding(channelID string, cfg Config, blockchainProvider blockchainClientProvider) *ConfigBlock {
+	h := newConfigBlock(
+		channelID, cfg,
+		fmt.Sprintf("%s/configblock", cfg.BasePath),
+		blockchainProvider,
+		dataEncodingParam,
+	)
+
+	h.getConfigBlock = h.getLatestConfigBlock
+
+	return h
+}
+
+// NewConfigBlockByHashHandler returns a new config block handler which returns the config block that
+// was used by the block with the provided block hash
+func NewConfigBlockByHashHandler(channelID string, cfg Config, blockchainProvider blockchainClientProvider) *ConfigBlock {
+	h := newConfigBlock(
+		channelID, cfg,
+		fmt.Sprintf("%s/configblock/{%s}", cfg.BasePath, hashParam),
+		blockchainProvider,
+	)
+
+	h.getConfigBlock = h.getConfigBlockByHash
+
+	return h
+}
+
+// NewConfigBlockByHashHandlerWithEncoding returns a new config block handler which returns the config block that
+// was used by the block with the provided block hash
+func NewConfigBlockByHashHandlerWithEncoding(channelID string, cfg Config, blockchainProvider blockchainClientProvider) *ConfigBlock {
+	h := newConfigBlock(
+		channelID, cfg,
+		fmt.Sprintf("%s/configblock/{%s}", cfg.BasePath, hashParam),
+		blockchainProvider,
+		dataEncodingParam,
+	)
+
+	h.getConfigBlock = h.getConfigBlockByHash
+
+	return h
+}
+
+func newConfigBlock(channelID string, cfg Config, path string, blockchainProvider blockchainClientProvider, params ...string) *ConfigBlock {
+	return &ConfigBlock{
+		handler: newHandler(
+			channelID, cfg, path, http.MethodGet,
+			blockchainProvider, params...,
+		),
+	}
+}
+
+// Handler returns the request handler
+func (h *ConfigBlock) Handler() common.HTTPRequestHandler {
+	return h.configBlock
+}
+
+func (h *ConfigBlock) configBlock(w http.ResponseWriter, req *http.Request) {
+	rw := newBlockchainWriter(w)
+
+	block, err := h.getConfigBlock(req)
+	if err != nil {
+		rw.WriteError(err)
+		return
+	}
+
+	infoBytes, err := h.jsonMarshal(block)
+	if err != nil {
+		logger.Errorf("Unable to marshal config block: %s", err)
+
+		rw.WriteError(httpserver.ServerError)
+		return
+	}
+
+	logger.Debugf("[%s] ... returning config block: %s", h.channelID, infoBytes)
+
+	rw.Write(infoBytes)
+}
+
+func (h *ConfigBlock) getLatestConfigBlock(req *http.Request) (Block, error) {
+	bcInfo, err := h.getBlockchainInfo()
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := h.getBlockByNum(bcInfo.Height - 1)
+	if err != nil {
+		logger.Errorf("[%s] Failed to get latest block %d: %s", h.channelID, bcInfo.Height-1, err)
+
+		return nil, httpserver.ServerError
+	}
+
+	return h.getConfigBlockFromMetadata(block, h.dataEncoding(req))
+}
+
+func (h *ConfigBlock) getConfigBlockByHash(req *http.Request) (Block, error) {
+	hash, encoding, err := h.getBlockByHashParams(req)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := h.getBlockByHash(hash)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.getConfigBlockFromMetadata(block, encoding)
+}
+
+func (h *ConfigBlock) getConfigBlockFromMetadata(block *cb.Block, encoding DataEncoding) (Block, error) {
+	configBlockNum, err := protoutil.GetLastConfigIndexFromBlock(block)
+	if err != nil {
+		logger.Errorf("[%s] Error getting config index from block: %s", h.channelID, err)
+
+		return nil, httpserver.ServerError
+	}
+
+	logger.Debugf("[%s] Got config block number [%d]", h.channelID, configBlockNum)
+
+	configBlock, err := h.getBlockByNum(configBlockNum)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, err := newBlockEncoder(encoding).encode(configBlock)
+	if err != nil {
+		return nil, err
+	}
+
+	return tree, nil
+}
+
+func (h *ConfigBlock) getBlockByHashParams(req *http.Request) (hash string, encoding DataEncoding, err error) {
+	hash = getHash(req)
+	if hash == "" {
+		return "", "", newBadRequestError(InvalidTimeHash)
+	}
+
+	encoding = h.dataEncoding(req)
+
+	logger.Debugf("[%s] Using params - hash=[%s], encoding=[%s]", h.channelID, hash, encoding)
+
+	return
+}

--- a/pkg/rest/blockchainhandler/configblockhandler_test.go
+++ b/pkg/rest/blockchainhandler/configblockhandler_test.go
@@ -1,0 +1,528 @@
+/*
+Copyright SecureKey Technologies Inc. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package blockchainhandler
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	cb "github.com/hyperledger/fabric-protos-go/common"
+	pb "github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/stretchr/testify/require"
+	"github.com/trustbloc/fabric-peer-ext/pkg/mocks"
+
+	"github.com/trustbloc/sidetree-fabric/pkg/httpserver"
+	obmocks "github.com/trustbloc/sidetree-fabric/pkg/observer/mocks"
+)
+
+const (
+	configBlockPath = "/blockchain/configblock"
+	blockNum        = uint64(999)
+	configBlockNum  = uint64(2)
+)
+
+func TestNewConfigBlockHandler(t *testing.T) {
+	h := NewConfigBlockHandler(channel1, handlerCfg, &obmocks.BlockchainClientProvider{})
+	require.NotNil(t, h)
+
+	require.Equal(t, configBlockPath, h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.Empty(t, h.Params())
+}
+
+func TestNewConfigBlockHandlerWithEncoding(t *testing.T) {
+	h := NewConfigBlockHandlerWithEncoding(channel1, handlerCfg, &obmocks.BlockchainClientProvider{})
+	require.NotNil(t, h)
+
+	require.Equal(t, configBlockPath, h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.Equal(t, map[string]string{"data-encoding": "{data-encoding}"}, h.Params())
+}
+
+func TestConfigBlock_Handler(t *testing.T) {
+	bcInfo := &cb.BlockchainInfo{
+		Height:           1000,
+		CurrentBlockHash: []byte{1, 2, 3, 4},
+	}
+
+	bcProvider := &obmocks.BlockchainClientProvider{}
+
+	t.Run("With default (JSON) encoding -> Success", func(t *testing.T) {
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+		bcClient.GetBlockByNumberReturnsOnCall(0, generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturnsOnCall(1, generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		var blockResp Block
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &blockResp))
+		require.NotNil(t, blockResp[headerField])
+		require.NotNil(t, blockResp[dataField])
+	})
+
+	t.Run("With base64 encoding -> Success", func(t *testing.T) {
+		restoreParams := setConfigBlockParams("", DataEncodingBase64)
+		defer restoreParams()
+
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+		bcClient.GetBlockByNumberReturnsOnCall(0, generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturnsOnCall(1, generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockHandlerWithEncoding(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		var block BlockResponse
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &block))
+		require.NotNil(t, block.Header)
+		require.Equal(t, configBlockNum, block.Header.Number)
+		require.NotEmpty(t, block.Header.DataHash)
+
+		dataBytes, err := base64.StdEncoding.DecodeString(block.Header.DataHash)
+		require.NoError(t, err)
+		require.NotEmpty(t, dataBytes)
+	})
+
+	t.Run("With base64URL encoding -> Success", func(t *testing.T) {
+		restoreParams := setConfigBlockParams("", DataEncodingBase64URL)
+		defer restoreParams()
+
+		const blockNum = uint64(999)
+
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+		bcClient.GetBlockByNumberReturnsOnCall(0, generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturnsOnCall(1, generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockHandlerWithEncoding(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		var block BlockResponse
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &block))
+		require.NotNil(t, block.Header)
+		require.Equal(t, configBlockNum, block.Header.Number)
+		require.NotEmpty(t, block.Header.DataHash)
+
+		dataBytes, err := base64.URLEncoding.DecodeString(block.Header.DataHash)
+		require.NoError(t, err)
+		require.NotEmpty(t, dataBytes)
+	})
+
+	t.Run("Marshal error -> Server Error", func(t *testing.T) {
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+		bcClient.GetBlockByNumberReturnsOnCall(0, generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturnsOnCall(1, generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+		h.jsonMarshal = func(v interface{}) ([]byte, error) { return nil, errors.New("injected marshal error") }
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+	})
+
+	t.Run("Blockchain provider error -> Server Error", func(t *testing.T) {
+		bcProvider.ForChannelReturns(nil, errors.New("injected blockchain provider error"))
+
+		h := NewConfigBlockHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+
+	t.Run("Blockchain info error -> Server Error", func(t *testing.T) {
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(nil, errors.New("injected blockchain client error"))
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+
+	t.Run("BlockByNumber error -> Server Error", func(t *testing.T) {
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+		bcClient.GetBlockByNumberReturns(nil, errors.New("injected blockchain client error"))
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+
+	t.Run("ConfigBlockByNumber error -> Server Error", func(t *testing.T) {
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
+		bcClient.GetBlockByNumberReturnsOnCall(0, generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturnsOnCall(1, nil, errors.New("injected blockchain client error"))
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+}
+
+func TestNewConfigBlockByHashHandler(t *testing.T) {
+	h := NewConfigBlockByHashHandler(channel1, handlerCfg, &obmocks.BlockchainClientProvider{})
+	require.NotNil(t, h)
+
+	require.Equal(t, "/blockchain/configblock/{hash}", h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.Empty(t, h.Params())
+}
+
+func TestNewConfigBlockByHashHandlerWithEncoding(t *testing.T) {
+	h := NewConfigBlockByHashHandlerWithEncoding(channel1, handlerCfg, &obmocks.BlockchainClientProvider{})
+	require.NotNil(t, h)
+
+	require.Equal(t, "/blockchain/configblock/{hash}", h.Path())
+	require.Equal(t, http.MethodGet, h.Method())
+	require.Equal(t, map[string]string{"data-encoding": "{data-encoding}"}, h.Params())
+}
+
+func TestConfigBlock_ByHashHandler(t *testing.T) {
+	const (
+		txn1 = "tx1"
+	)
+
+	bcProvider := &obmocks.BlockchainClientProvider{}
+
+	t.Run("With default (JSON) encoding -> Success", func(t *testing.T) {
+		restoreParams := setConfigBlockParams(base64.URLEncoding.EncodeToString([]byte("hash1")), "")
+		defer restoreParams()
+
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockByHashReturns(generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturns(generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockByHashHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		var blockResp Block
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &blockResp))
+		require.NotNil(t, blockResp[headerField])
+		require.NotNil(t, blockResp[dataField])
+	})
+
+	t.Run("With base64 encoding -> Success", func(t *testing.T) {
+		restoreParams := setConfigBlockParams(base64.URLEncoding.EncodeToString([]byte("hash1")), DataEncodingBase64)
+		defer restoreParams()
+
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockByHashReturns(generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturns(generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockByHashHandlerWithEncoding(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		var blockResp BlockResponse
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &blockResp))
+		require.NotNil(t, blockResp.Header)
+		require.Equal(t, configBlockNum, blockResp.Header.Number)
+		require.NotEmpty(t, blockResp.Header.DataHash)
+
+		dataBytes, err := base64.StdEncoding.DecodeString(blockResp.Header.DataHash)
+		require.NoError(t, err)
+		require.NotEmpty(t, dataBytes)
+	})
+
+	t.Run("With base64URL encoding -> Success", func(t *testing.T) {
+		restoreParams := setConfigBlockParams(base64.URLEncoding.EncodeToString([]byte("hash1")), DataEncodingBase64URL)
+		defer restoreParams()
+
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockByHashReturns(generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturns(generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockByHashHandlerWithEncoding(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusOK, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		var blockResp BlockResponse
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), &blockResp))
+		require.NotNil(t, blockResp.Header)
+		require.Equal(t, configBlockNum, blockResp.Header.Number)
+		require.NotEmpty(t, blockResp.Header.DataHash)
+
+		dataBytes, err := base64.URLEncoding.DecodeString(blockResp.Header.DataHash)
+		require.NoError(t, err)
+		require.NotEmpty(t, dataBytes)
+	})
+
+	t.Run("Missing hash param -> BadRequest", func(t *testing.T) {
+		testInvalidConfigParams(t, NewConfigBlockByHashHandler, InvalidTimeHash)
+	})
+
+	t.Run("Invalid hash param -> BadRequest", func(t *testing.T) {
+		restoreParams := setConfigBlockParams("xxx", "")
+		defer restoreParams()
+
+		testInvalidConfigParams(t, NewConfigBlockByHashHandler, InvalidTimeHash)
+	})
+
+	t.Run("Marshal error -> Server Error", func(t *testing.T) {
+		restoreParams := setConfigBlockParams(base64.URLEncoding.EncodeToString([]byte("hash1")), "")
+		defer restoreParams()
+
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockByHashReturns(generateBlock(t, blockNum, configBlockNum), nil)
+		bcClient.GetBlockByNumberReturns(generateConfigBlock(t, configBlockNum), nil)
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockByHashHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+		h.jsonMarshal = func(v interface{}) ([]byte, error) { return nil, errors.New("injected marshal error") }
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+	})
+
+	t.Run("Blockchain provider error -> Server Error", func(t *testing.T) {
+		restoreParams := setConfigBlockParams(base64.URLEncoding.EncodeToString([]byte("hash1")), "")
+		defer restoreParams()
+
+		bcProvider.ForChannelReturns(nil, errors.New("injected blockchain provider error"))
+
+		h := NewConfigBlockByHashHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+
+	t.Run("Blockchain client error -> Server Error", func(t *testing.T) {
+		restoreParams := setConfigBlockParams(base64.URLEncoding.EncodeToString([]byte("hash1")), "")
+		defer restoreParams()
+
+		bcClient := &obmocks.BlockchainClient{}
+		bcClient.GetBlockByHashReturns(nil, errors.New("injected blockchain client error"))
+
+		bcProvider.ForChannelReturns(bcClient, nil)
+
+		h := NewConfigBlockByHashHandler(channel1, handlerCfg, bcProvider)
+		require.NotNil(t, h)
+
+		rw := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+		h.Handler()(rw, req)
+
+		require.Equal(t, http.StatusInternalServerError, rw.Result().StatusCode)
+		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
+		require.Equal(t, httpserver.StatusServerError, rw.Body.String())
+	})
+}
+
+type configHandlerCreator func(channelID string, cfg Config, blockchainProvider blockchainClientProvider) *ConfigBlock
+
+func testInvalidConfigParams(t *testing.T, newHandler configHandlerCreator, expectedCode ResultCode) {
+	const (
+		txn1 = "tx1"
+	)
+
+	bcClient := &obmocks.BlockchainClient{}
+	bcClient.GetBlockByHashReturns(generateBlock(t, blockNum, configBlockNum), nil)
+	bcClient.GetBlockByNumberReturns(generateConfigBlock(t, configBlockNum), nil)
+
+	bcProvider := &obmocks.BlockchainClientProvider{}
+	bcProvider.ForChannelReturns(bcClient, nil)
+
+	rw := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, configBlockPath, nil)
+
+	h := newHandler(channel1, handlerCfg, bcProvider)
+	require.NotNil(t, h)
+
+	h.Handler()(rw, req)
+
+	require.Equal(t, http.StatusBadRequest, rw.Result().StatusCode)
+	require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+	errResp := &ErrorResponse{}
+	require.NoError(t, json.Unmarshal(rw.Body.Bytes(), errResp))
+	require.Equal(t, expectedCode, errResp.Code)
+}
+
+func setConfigBlockParams(hash string, encoding DataEncoding) func() {
+	restoreGetHash := getHash
+	restoreGetDataEncoding := getDataEncoding
+
+	getHash = func(_ *http.Request) string {
+		return hash
+	}
+
+	getDataEncoding = func(_ *http.Request) DataEncoding {
+		return encoding
+	}
+
+	return func() {
+		getHash = restoreGetHash
+		getDataEncoding = restoreGetDataEncoding
+	}
+}
+
+func generateBlock(t *testing.T, blockNum, cfgBlockNum uint64) *cb.Block {
+	bb := mocks.NewBlockBuilder(channel1, blockNum)
+	bb.Transaction("txn1", pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write("key1", []byte("value1"))
+
+	block := bb.Build()
+	block.Metadata = generateConfigMetaData(t, cfgBlockNum)
+
+	return block
+}
+
+func generateConfigBlock(t *testing.T, blockNum uint64) *cb.Block {
+	cfgbb := mocks.NewBlockBuilder(channel1, configBlockNum)
+	cfgbb.ConfigUpdate()
+	return cfgbb.Build()
+}
+
+func generateConfigMetaData(t *testing.T, cfgBlockNum uint64) *cb.BlockMetadata {
+	obm := &cb.OrdererBlockMetadata{
+		LastConfig: &cb.LastConfig{
+			Index: cfgBlockNum,
+		},
+	}
+
+	obmBytes, err := proto.Marshal(obm)
+	require.NoError(t, err)
+
+	md := &cb.Metadata{
+		Value: obmBytes,
+	}
+
+	sigBytes, err := proto.Marshal(md)
+	require.NoError(t, err)
+
+	return &cb.BlockMetadata{
+		Metadata: [][]byte{sigBytes},
+	}
+}

--- a/pkg/rest/blockchainhandler/handler.go
+++ b/pkg/rest/blockchainhandler/handler.go
@@ -74,7 +74,7 @@ func (h *handler) getBlockByHash(strHash string) (*cb.Block, error) {
 	if err != nil {
 		logger.Debugf("Invalid base64 encoded hash [%s]: %s", strHash, err)
 
-		return nil, httpserver.NewError(http.StatusBadRequest, httpserver.StatusBadRequest)
+		return nil, newBadRequestError(InvalidTimeHash)
 	}
 
 	bcClient, err := h.blockchainClient()

--- a/pkg/rest/blockchainhandler/timehandler.go
+++ b/pkg/rest/blockchainhandler/timehandler.go
@@ -77,7 +77,7 @@ func (h *Time) Handler() common.HTTPRequestHandler {
 }
 
 func (h *Time) time(w http.ResponseWriter, req *http.Request) {
-	rw := httpserver.NewResponseWriter(w)
+	rw := newBlockchainWriter(w)
 
 	time, err := h.getTime(req)
 	if err != nil {
@@ -95,7 +95,7 @@ func (h *Time) time(w http.ResponseWriter, req *http.Request) {
 
 	logger.Debugf("[%s] ... returning blockchain time: %s", h.channelID, timeBytes)
 
-	rw.Write(http.StatusOK, timeBytes, httpserver.ContentTypeJSON)
+	rw.Write(timeBytes)
 }
 
 func (h *Time) getLatestTime(req *http.Request) (*TimeResponse, error) {

--- a/pkg/rest/blockchainhandler/timehandler_test.go
+++ b/pkg/rest/blockchainhandler/timehandler_test.go
@@ -241,8 +241,11 @@ func TestTime_ByHash(t *testing.T) {
 		h.Handler()(rw, req)
 
 		require.Equal(t, http.StatusBadRequest, rw.Result().StatusCode)
-		require.Equal(t, httpserver.ContentTypeText, rw.Header().Get(httpserver.ContentTypeHeader))
-		require.Equal(t, httpserver.StatusBadRequest, rw.Body.String())
+		require.Equal(t, httpserver.ContentTypeJSON, rw.Header().Get(httpserver.ContentTypeHeader))
+
+		errResp := &ErrorResponse{}
+		require.NoError(t, json.Unmarshal(rw.Body.Bytes(), errResp))
+		require.Equal(t, InvalidTimeHash, errResp.Code)
 	})
 
 	t.Run("Marshal error -> Server Error", func(t *testing.T) {

--- a/test/bddtests/features/blockchain-handler.feature
+++ b/test/bddtests/features/blockchain-handler.feature
@@ -212,6 +212,45 @@ Feature:
     And the JSON path "0.data" of the response is saved to variable "block-data"
     Then the hash of the base64URL-encoded value "${block-data}" equals "${data-hash}"
 
+    # Retrieve the config block for the given block number and make check the channel header type
+    # to ensure the block is a config block. Following are the channel header types:
+    #  MESSAGE              : 0
+    #  CONFIG               : 1
+    #  CONFIG_UPDATE        : 2
+    #  ENDORSER_TRANSACTION : 3
+    #  ORDERER_TRANSACTION  : 4
+    #  DELIVER_SEEK_INFO    : 5
+    #  CHAINCODE_PACKAGE    : 6
+    #  PEER_ADMIN_OPERATION : 8
+
+    # Get the latest config block (the data is in JSON format)
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/configblock"
+    And the JSON path "data.data.0.payload.header.channel_header.type" of the numeric response equals "1"
+    # Get the latest config block (the data is base64-encoded)
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/configblock?data-encoding=base64"
+    And the JSON path "header.data_hash" of the response is saved to variable "config-data-hash"
+    And the JSON path "data" of the response is saved to variable "config-data"
+    Then the hash of the base64-encoded value "${config-data}" equals "${config-data-hash}"
+    # Get the latest config block (the data is base64URL-encoded)
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/configblock?data-encoding=base64url"
+    And the JSON path "header.data_hash" of the response is saved to variable "config-data-hash"
+    And the JSON path "data" of the response is saved to variable "config-data"
+    Then the hash of the base64URL-encoded value "${config-data}" equals "${config-data-hash}"
+
+    # Get the config block that was used by the block with the given hash (the data is in JSON format)
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/configblock/${url-encoded-previous-hash}"
+    And the JSON path "data.data.0.payload.header.channel_header.type" of the numeric response equals "1"
+    # Get the config block that was used by the block with the given hash (the data is base64-encoded)
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/configblock/${url-encoded-previous-hash}?data-encoding=base64"
+    And the JSON path "header.data_hash" of the response is saved to variable "config-data-hash"
+    And the JSON path "data" of the response is saved to variable "config-data"
+    Then the hash of the base64-encoded value "${config-data}" equals "${config-data-hash}"
+    # Get the config block that was used by the block with the given hash (the data is base64URL-encoded)
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/configblock/${url-encoded-previous-hash}?data-encoding=base64url"
+    And the JSON path "header.data_hash" of the response is saved to variable "config-data-hash"
+    And the JSON path "data" of the response is saved to variable "config-data"
+    Then the hash of the base64URL-encoded value "${config-data}" equals "${config-data-hash}"
+
   @invalid_blockchain_config
   Scenario: Invalid configuration
     Given fabric-cli context "mychannel" is used


### PR DESCRIPTION
Added a REST endpoint that retrieves a config block. If a hash is specified then the block for that hash is retrieved and the last config index is extracted from the metadata section of that block. This index is used to retrieve the config block.
If no hash is specified then the latest block in the chain is retrieved and the config block is retrieved using the last config index of that block.
By default the data sections (data and metadata) of the returned config block are encoded in JSON format. But if the data-encoding parameter is set to 'base64' or 'base64url' then the data sections are encoded in base64 or base64url respectively.

closes #220

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>