### PR TITLE
chore: Update sidetree-core (service validation)

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -367,8 +367,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b h1:wVscI1/+oJq3bYvyPiRTytZo9+HCU0GZ76wuGzAQbGQ=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836 h1:moG4HZ0GMQRg4ksr8Gu1URw9fQBIitYwgWs9zQMgkWo=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3-0.20200420201434-ba9a41234a50

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200421205558-934bc094d380/go.mod h1:6G1U2FPPA3dUr3Xwj3iYeatBsq2O2MLE1jraqWdyoZM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b h1:wVscI1/+oJq3bYvyPiRTytZo9+HCU0GZ76wuGzAQbGQ=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836 h1:moG4HZ0GMQRg4ksr8Gu1URw9fQBIitYwgWs9zQMgkWo=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -78,13 +78,13 @@ const docTemplate = `{
   		"jwk": %s
 	},
    {
-     "id": "dual-auth-general",
+     "id": "dual-auth-gen",
      "type": "JwsVerificationKey2020",
      "usage": ["auth", "general"],
      "jwk": %s
    },
    {
-     "id": "dual-assertion-general",
+     "id": "dual-assertion-gen",
      "type": "Ed25519VerificationKey2018",
      "usage": ["assertion", "general"],
      "jwk": %s

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200428204902-1d34830c6905
-	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b
+	github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.2

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -209,8 +209,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200428204902-1d34830c690
 github.com/trustbloc/fabric-peer-test-common v0.1.3-0.20200428204902-1d34830c6905/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2 h1:oaUgVfwJzKJo7krUrf5F1lJPFiYw1GjoUaNERoOu8zM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.2/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b h1:wVscI1/+oJq3bYvyPiRTytZo9+HCU0GZ76wuGzAQbGQ=
-github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429132924-5ec11da3314b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836 h1:moG4HZ0GMQRg4ksr8Gu1URw9fQBIitYwgWs9zQMgkWo=
+github.com/trustbloc/sidetree-core-go v0.1.3-0.20200429221156-29aa142ef836/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Included:

- add service patch validation
- pub key and service id validation
- initial document validation includes services
- validation of all patches when parsing operation deltas (before operation is accepted)
- remove public keys and remove services patch validation

Closes #267

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>