### PR TITLE
fix: Ensure that query params are propagated from auth handler

### DIFF
--- a/pkg/rest/authhandler/authhandler.go
+++ b/pkg/rest/authhandler/authhandler.go
@@ -49,6 +49,16 @@ func (h *Handler) Handler() common.HTTPRequestHandler {
 	return h.handle
 }
 
+// Params returns the parameters
+func (h *Handler) Params() map[string]string {
+	ph, ok := h.HTTPHandler.(paramHolder)
+	if ok {
+		return ph.Params()
+	}
+
+	return nil
+}
+
 func (h *Handler) handle(w http.ResponseWriter, r *http.Request) {
 	if !h.isAuthorized(r) {
 		logger.Debugf("[%s] Caller is not authorized for %s on path [%s]", h.channelID, h.Method(), h.Path())
@@ -78,4 +88,8 @@ func (h *Handler) isAuthorized(r *http.Request) bool {
 	}
 
 	return false
+}
+
+type paramHolder interface {
+	Params() map[string]string
 }

--- a/test/bddtests/features/blockchain-handler.feature
+++ b/test/bddtests/features/blockchain-handler.feature
@@ -112,7 +112,7 @@ Feature:
     And the JSON path "batchFileHash" of the response is saved to variable "batchFileHash"
 
     # Ensure that the batch file hash resolves to a valid value stored in DCAS
-    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${batchFileHash}?max-size=8192"
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${batchFileHash}?max-size=24000"
     And the JSON path "operations" of the array response is not empty
 
     # Invalid since


### PR DESCRIPTION
closes #275

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>