### PR TITLE
chore: Update to latest fabric-peer-ext

### DIFF
--- a/cmd/peer/go.mod
+++ b/cmd/peer/go.mod
@@ -13,9 +13,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200512130415-03d3b457d733
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200512130415-03d3b457d733
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200513140903-fa5dc82ba566
 
 replace github.com/trustbloc/sidetree-fabric => ../..
 

--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -361,10 +361,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.3 h1:d+lDd2OTApQnFQcwu7i/TJqGhTcLfU8pCYr703t3mSA=
 github.com/trustbloc/fabric-mod v0.1.3/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200512130415-03d3b457d733 h1:zDDda5nkFmy1/FMIb4VacHvDDsWi2NF2cisq9fQLhBU=
-github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200512130415-03d3b457d733/go.mod h1:C29F1APiYWLtiUMMQjOLd91CPKbYOShgiVM/5JZdN7g=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200512130415-03d3b457d733 h1:G4tAN5pL4BZprsJiXZd9APVqizwiMP40qDE1qDRScFE=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200512130415-03d3b457d733/go.mod h1:ItqeXATVAL/6ORMbKCti3oKR6ZisVt5S9FnD9F9bQFg=
+github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200513140903-fa5dc82ba566 h1:jjn6MwakQlepj9hv83lwvbzdqnfqwv/E2l4k6FyUZjw=
+github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200513140903-fa5dc82ba566/go.mod h1:C29F1APiYWLtiUMMQjOLd91CPKbYOShgiVM/5JZdN7g=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566 h1:2RAZqQiBWMbzXqLxEP6hptwGdrPmpfPvSxrKxmAXkn4=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566/go.mod h1:ItqeXATVAL/6ORMbKCti3oKR6ZisVt5S9FnD9F9bQFg=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3 h1:f426k4Txm1O7zKHLmgLJ9wkUn0nQBKR9fFoZDItEfSw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3 h1:p3Rgk0w8unimzc6QsISB3dwOS+4J/W8zWTM6siqMnoA=

--- a/go.mod
+++ b/go.mod
@@ -31,9 +31,9 @@ require (
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3
 
-replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200512130415-03d3b457d733
+replace github.com/hyperledger/fabric/extensions => github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566
 
-replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200512130415-03d3b457d733
+replace github.com/trustbloc/fabric-peer-ext => github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200513140903-fa5dc82ba566
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.3
 

--- a/go.sum
+++ b/go.sum
@@ -372,10 +372,10 @@ github.com/tedsuo/ifrit v0.0.0-20180802180643-bea94bb476cc/go.mod h1:eyZnKCc955u
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/fabric-mod v0.1.3 h1:d+lDd2OTApQnFQcwu7i/TJqGhTcLfU8pCYr703t3mSA=
 github.com/trustbloc/fabric-mod v0.1.3/go.mod h1:mNPoGD7ygdNtnRLVsiY2YFYfcFSj4mEpyXILRXxByAs=
-github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200512130415-03d3b457d733 h1:zDDda5nkFmy1/FMIb4VacHvDDsWi2NF2cisq9fQLhBU=
-github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200512130415-03d3b457d733/go.mod h1:C29F1APiYWLtiUMMQjOLd91CPKbYOShgiVM/5JZdN7g=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200512130415-03d3b457d733 h1:G4tAN5pL4BZprsJiXZd9APVqizwiMP40qDE1qDRScFE=
-github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200512130415-03d3b457d733/go.mod h1:ItqeXATVAL/6ORMbKCti3oKR6ZisVt5S9FnD9F9bQFg=
+github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200513140903-fa5dc82ba566 h1:jjn6MwakQlepj9hv83lwvbzdqnfqwv/E2l4k6FyUZjw=
+github.com/trustbloc/fabric-peer-ext v0.1.4-0.20200513140903-fa5dc82ba566/go.mod h1:C29F1APiYWLtiUMMQjOLd91CPKbYOShgiVM/5JZdN7g=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566 h1:2RAZqQiBWMbzXqLxEP6hptwGdrPmpfPvSxrKxmAXkn4=
+github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566/go.mod h1:ItqeXATVAL/6ORMbKCti3oKR6ZisVt5S9FnD9F9bQFg=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3 h1:f426k4Txm1O7zKHLmgLJ9wkUn0nQBKR9fFoZDItEfSw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.3 h1:p3Rgk0w8unimzc6QsISB3dwOS+4J/W8zWTM6siqMnoA=

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -608,6 +608,8 @@ func (d *DIDSideSteps) verifyDIDDocuments(urlsExpr string) error {
 		}
 	}
 
+	d.dids = nil
+
 	return nil
 }
 


### PR DESCRIPTION
Updated to the latest fabric-peer-ext that fixes a panic when reading blockchain checkpoint info.

Also added a fix for a minor bug in the BDD test.

closes #307

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>