### PR TITLE
fix: Retry on DB errors in Observer

### DIFF
--- a/pkg/context/blockchain/client.go
+++ b/pkg/context/blockchain/client.go
@@ -10,6 +10,8 @@ import (
 	"github.com/pkg/errors"
 	txnapi "github.com/trustbloc/fabric-peer-ext/pkg/txn/api"
 	"github.com/trustbloc/sidetree-core-go/pkg/observer"
+
+	"github.com/trustbloc/sidetree-fabric/pkg/common/transienterr"
 )
 
 const (
@@ -48,7 +50,7 @@ func (c *Client) WriteAnchor(anchor string) error {
 		Args:        [][]byte{[]byte(writeAnchorFcn), []byte(anchor)},
 	})
 	if err != nil {
-		return errors.Wrap(err, "failed to store anchor file address")
+		return transienterr.New(errors.Wrap(err, "failed to store anchor file address"))
 	}
 
 	return nil

--- a/pkg/context/cas/client.go
+++ b/pkg/context/cas/client.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas/client"
 
+	"github.com/trustbloc/sidetree-fabric/pkg/common/transienterr"
 	"github.com/trustbloc/sidetree-fabric/pkg/config"
 )
 
@@ -40,7 +41,13 @@ func (c *Client) Write(content []byte) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return dcasClient.Put(c.ChaincodeName, c.Collection, content)
+
+	key, err := dcasClient.Put(c.ChaincodeName, c.Collection, content)
+	if err != nil {
+		return "", transienterr.New(err)
+	}
+
+	return key, nil
 }
 
 // Read reads the content at the given address from content addressable storage
@@ -53,7 +60,7 @@ func (c *Client) Read(address string) ([]byte, error) {
 
 	data, err := dcasClient.Get(c.ChaincodeName, c.Collection, address)
 	if err != nil {
-		return nil, err
+		return nil, transienterr.New(err)
 	}
 
 	if len(data) == 0 {

--- a/pkg/context/store/client.go
+++ b/pkg/context/store/client.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/batch"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
+
+	"github.com/trustbloc/sidetree-fabric/pkg/common/transienterr"
 )
 
 const (
@@ -57,14 +59,14 @@ func (c *Client) Get(uniqueSuffix string) ([]*batch.Operation, error) {
 
 	iter, err := c.store.Query(fmt.Sprintf(queryByIDTemplate, id))
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to query document operations")
+		return nil, transienterr.New(errors.Wrap(err, "failed to query document operations"))
 	}
 
 	var ops [][]byte
 	for {
 		next, err := iter.Next()
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to retrieve key and value in the range")
+			return nil, transienterr.New(errors.Wrap(err, "failed to retrieve key and value in the range"))
 		}
 		if next == nil {
 			break
@@ -95,7 +97,7 @@ func (c *Client) Put(ops []*batch.Operation) error {
 
 		err = c.store.Put(bytes)
 		if err != nil {
-			return err
+			return transienterr.New(err)
 		}
 	}
 


### PR DESCRIPTION
Errors related to DB reads/writes are marked as transient so that the Observer may retry at a later time.

closes #310

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>