### PR TITLE
feat: Keep track of failures in Observer metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,9 @@ FABRIC_PEER_EXT_IMAGE   ?= trustbloc/fabric-peer
 FABRIC_PEER_EXT_VERSION ?= 0.1.2
 FABRIC_PEER_EXT_TAG     ?= $(ARCH)-$(FABRIC_PEER_EXT_VERSION)
 
-export FABRIC_CLI_EXT_VERSION ?= 4ed7815d3158d1b75c252ad59cefc8054e535c55
+export FABRIC_CLI_EXT_VERSION ?= 61c2cb1f92926522c280ed243e18d506be12906c
 
-# Namespace for the blocnode image
+# Namespace for the Sidetree Fabric peer image
 DOCKER_OUTPUT_NS           ?= docker.pkg.github.com/trustbloc/sidetree-fabric
 SIDETREE_FABRIC_IMAGE_NAME ?= peer
 SIDETREE_FABRIC_IMAGE_TAG  ?= latest

--- a/pkg/common/transienterr/transienterr.go
+++ b/pkg/common/transienterr/transienterr.go
@@ -7,21 +7,62 @@ SPDX-License-Identifier: Apache-2.0
 package transienterr
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
+)
+
+// Code is the error code
+type Code string
+
+const (
+	// CodeUnknown is an unspecified error code
+	CodeUnknown Code = "UNKNOWN"
+	// CodeNotFound indicates that an item was not found
+	CodeNotFound Code = "NOT_FOUND"
+	// CodeBlockchain indicates that an error occurred while committing a transaction to the blockchain
+	CodeBlockchain Code = "BLOCKCHAIN"
+	// CodeDB indicates that an error occurred while accessing the database
+	CodeDB Code = "DB"
 )
 
 // Error is a transient error, meaning that a retry on the request may succeed
 type Error struct {
 	error
+	code Code
 }
 
 // New returns a transient error which wraps the given error
-func New(cause error) Error {
-	return Error{error: cause}
+// and assigns the given code
+func New(cause error, code Code) Error {
+	return Error{
+		error: cause,
+		code:  code,
+	}
+}
+
+// String returns the string representation of the error
+func (err *Error) String() string {
+	return fmt.Sprintf("%s - Code: %s", err.Error(), err.code)
 }
 
 // Is returns true if the given error is a transient error
 func Is(err error) bool {
 	_, ok := errors.Cause(err).(Error)
 	return ok
+}
+
+// GetCode returns true if the given error is a transient error
+func GetCode(err error) Code {
+	terr, ok := errors.Cause(err).(Error)
+	if !ok {
+		return CodeUnknown
+	}
+
+	return terr.code
+}
+
+// Code is the error code
+func (err *Error) Code() Code {
+	return err.code
 }

--- a/pkg/common/transienterr/transienterr_test.go
+++ b/pkg/common/transienterr/transienterr_test.go
@@ -15,15 +15,20 @@ import (
 
 func TestError(t *testing.T) {
 	cause := errors.New("cause of error")
-	err := New(cause)
+	err := New(cause, CodeNotFound)
 	require.NotNil(t, err)
 	require.Equal(t, cause.Error(), err.Error())
+	require.Equal(t, CodeNotFound, err.Code())
+	require.Equal(t, CodeNotFound, GetCode(err))
+	require.Equal(t, "cause of error - Code: NOT_FOUND", err.String())
 }
 
 func TestIs(t *testing.T) {
 	cause := errors.New("cause of error")
-	err := New(cause)
+	err := New(cause, CodeDB)
 	require.NotNil(t, err)
 	require.True(t, Is(err))
+	require.Equal(t, CodeDB, GetCode(err))
 	require.False(t, Is(cause))
+	require.Equal(t, CodeUnknown, GetCode(cause))
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,8 +19,14 @@ import (
 
 // Observer holds Sidetree Observer config
 type Observer struct {
-	Period                time.Duration
+	// Period is the scheduled period for processing blocks
+	Period time.Duration
+	// MetaDataChaincodeName is the name of the chaincode that stores metadata
 	MetaDataChaincodeName string
+	// MaxAttempts is the maximum number of attempts to process a transaction. When a transient error
+	// occurs then a retry is attempted at the next scheduled interval. After processing has failed
+	// MaxAttempts times, the batch is lost and processing continues at the next transaction in the block.
+	MaxAttempts int
 }
 
 // SidetreePeer holds peer-specific Sidetree config

--- a/pkg/context/blockchain/client.go
+++ b/pkg/context/blockchain/client.go
@@ -50,7 +50,7 @@ func (c *Client) WriteAnchor(anchor string) error {
 		Args:        [][]byte{[]byte(writeAnchorFcn), []byte(anchor)},
 	})
 	if err != nil {
-		return transienterr.New(errors.Wrap(err, "failed to store anchor file address"))
+		return transienterr.New(errors.Wrap(err, "failed to store anchor file address"), transienterr.CodeBlockchain)
 	}
 
 	return nil

--- a/pkg/context/cas/client.go
+++ b/pkg/context/cas/client.go
@@ -44,7 +44,7 @@ func (c *Client) Write(content []byte) (string, error) {
 
 	key, err := dcasClient.Put(c.ChaincodeName, c.Collection, content)
 	if err != nil {
-		return "", transienterr.New(err)
+		return "", transienterr.New(err, transienterr.CodeDB)
 	}
 
 	return key, nil
@@ -60,11 +60,11 @@ func (c *Client) Read(address string) ([]byte, error) {
 
 	data, err := dcasClient.Get(c.ChaincodeName, c.Collection, address)
 	if err != nil {
-		return nil, transienterr.New(err)
+		return nil, transienterr.New(err, transienterr.CodeDB)
 	}
 
 	if len(data) == 0 {
-		return nil, errors.Errorf("content not found for key [%s]", address)
+		return nil, transienterr.New(errors.Errorf("content not found for key [%s]", address), transienterr.CodeNotFound)
 	}
 
 	return data, nil

--- a/pkg/context/store/client.go
+++ b/pkg/context/store/client.go
@@ -59,14 +59,14 @@ func (c *Client) Get(uniqueSuffix string) ([]*batch.Operation, error) {
 
 	iter, err := c.store.Query(fmt.Sprintf(queryByIDTemplate, id))
 	if err != nil {
-		return nil, transienterr.New(errors.Wrap(err, "failed to query document operations"))
+		return nil, transienterr.New(errors.Wrap(err, "failed to query document operations"), transienterr.CodeDB)
 	}
 
 	var ops [][]byte
 	for {
 		next, err := iter.Next()
 		if err != nil {
-			return nil, transienterr.New(errors.Wrap(err, "failed to retrieve key and value in the range"))
+			return nil, transienterr.New(errors.Wrap(err, "failed to retrieve key and value in the range"), transienterr.CodeDB)
 		}
 		if next == nil {
 			break
@@ -97,7 +97,7 @@ func (c *Client) Put(ops []*batch.Operation) error {
 
 		err = c.store.Put(bytes)
 		if err != nil {
-			return transienterr.New(err)
+			return transienterr.New(err, transienterr.CodeDB)
 		}
 	}
 

--- a/pkg/observer/dcasreader.go
+++ b/pkg/observer/dcasreader.go
@@ -35,16 +35,16 @@ func NewSidetreeDCASReader(channelID string, dcasCfg config.DCAS, dcasClientProv
 func (r *SidetreeDCASReader) Read(key string) ([]byte, error) {
 	dcasClient, err := r.dcasClient()
 	if err != nil {
-		return nil, transienterr.New(err)
+		return nil, transienterr.New(err, transienterr.CodeUnknown)
 	}
 
 	content, err := dcasClient.Get(r.ChaincodeName, r.Collection, key)
 	if err != nil {
-		return nil, transienterr.New(err)
+		return nil, transienterr.New(err, transienterr.CodeDB)
 	}
 
 	if len(content) == 0 {
-		return nil, errors.Errorf("content not found for key [%s]", key)
+		return nil, transienterr.New(errors.Errorf("content not found for key [%s]", key), transienterr.CodeNotFound)
 	}
 
 	return content, nil

--- a/pkg/peer/config/sidetreepeervalidator.go
+++ b/pkg/peer/config/sidetreepeervalidator.go
@@ -93,7 +93,11 @@ func (v *sidetreePeerValidator) validateHandlerConfig(kv *config.KeyValue) error
 
 func (v *sidetreePeerValidator) validateObserver(kv *config.KeyValue, cfg sidetreecfg.Observer) error {
 	if cfg.Period == 0 {
-		logger.Infof("The Sidetree monitor period is set to 0 and therefore the default value will be used for [%s].", kv.PeerID)
+		logger.Infof("The Sidetree observer period is set to 0 and therefore the default value will be used for [%s].", kv.PeerID)
+	}
+
+	if cfg.MaxAttempts == 0 {
+		logger.Infof("Sidetree observer MaxAttempts is set to 0 and therefore the default value will be used for [%s].", kv.PeerID)
 	}
 
 	if cfg.MetaDataChaincodeName == "" {

--- a/test/bddtests/fixtures/config/fabric/sidetree-config.json
+++ b/test/bddtests/fixtures/config/fabric/sidetree-config.json
@@ -1,6 +1,7 @@
 {
   "Observer": {
-    "Period": "10s",
-    "MetaDataChaincodeName": "document"
+    "Period": "5s",
+    "MetaDataChaincodeName": "document",
+    "MaxAttempts": 3
   }
 }

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -205,7 +205,6 @@ github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200511225148-de0c44fbba2a/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200517170823-9f98d46a0e0f h1:dS8ph1qmLtOuhuodnvNOssmcjEylxBHnHMdwY/Hpzjw=
 github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200517170823-9f98d46a0e0f/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3 h1:f426k4Txm1O7zKHLmgLJ9wkUn0nQBKR9fFoZDItEfSw=


### PR DESCRIPTION
Added new fields to metadata in order to keep track of failures when processing blocks. The following fields were added:
- LastTxNumProcessed: The last transaction within the block that was processed
- LastErrorCode: The error code that was received processing the last transaction
- FailedAttempts: The number of failed attempts processing the transaction

Also added a field to the Observer configuration:
- MaxAttempts: The maximum number of attempts to process a transaction. When a transient error occurs then a retry is attempted at the next scheduled interval. After processing has failed MaxAttempts times then the batch is lost and processing continues at the next transaction in the block.

closes #318

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>