### PR TITLE
refactor: Refactored Remove function in operation queue

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -367,8 +367,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566/go.mod h1:ItqeXATVAL/6ORMbKCti3oKR6ZisVt5S9FnD9F9bQFg=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3 h1:f426k4Txm1O7zKHLmgLJ9wkUn0nQBKR9fFoZDItEfSw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b h1:J3IcuMqP1uRKOXQ6EaMiVo5oPfSFpZaZM2MJ5JIQjig=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15 h1:+s9KX+mJGo5mEm2IK9IwvmXGH9jtZgVq8xnNmnLQJ74=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.3

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200513140903-fa5dc82ba566/go.mod h1:ItqeXATVAL/6ORMbKCti3oKR6ZisVt5S9FnD9F9bQFg=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3 h1:f426k4Txm1O7zKHLmgLJ9wkUn0nQBKR9fFoZDItEfSw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b h1:J3IcuMqP1uRKOXQ6EaMiVo5oPfSFpZaZM2MJ5JIQjig=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15 h1:+s9KX+mJGo5mEm2IK9IwvmXGH9jtZgVq8xnNmnLQJ74=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/context/operationqueue/leveldbqueue_test.go
+++ b/pkg/context/operationqueue/leveldbqueue_test.go
@@ -62,19 +62,16 @@ func TestLevelDBQueue(t *testing.T) {
 	require.Equal(t, op1, ops[0])
 	require.Equal(t, op2, ops[1])
 
-	ops, n, err = q.Remove(2)
+	removed, n, err := q.Remove(2)
 	require.NoError(t, err)
 	require.Equal(t, uint(1), n)
-	require.Len(t, ops, 2)
-	require.Equal(t, op1, ops[0])
-	require.Equal(t, op2, ops[1])
+	require.Equal(t, uint(2), removed)
 	require.Equal(t, uint(1), q.Len())
 
-	ops, n, err = q.Remove(2)
+	removed, n, err = q.Remove(2)
 	require.NoError(t, err)
 	require.Equal(t, uint(0), n)
-	require.Len(t, ops, 1)
-	require.Equal(t, op3, ops[0])
+	require.Equal(t, uint(1), removed)
 }
 
 func TestLevelDBQueue_Reload(t *testing.T) {
@@ -101,9 +98,9 @@ func TestLevelDBQueue_Reload(t *testing.T) {
 	require.Equal(t, uint(4), n)
 	require.Equal(t, uint(4), q.Len())
 
-	op, l, err := q.Remove(1)
+	removed, l, err := q.Remove(1)
 	require.NoError(t, err)
-	require.Equal(t, op1, op[0])
+	require.Equal(t, uint(1), removed)
 
 	require.Equal(t, uint(3), l)
 	require.Equal(t, uint(3), q.Len())
@@ -116,18 +113,15 @@ func TestLevelDBQueue_Reload(t *testing.T) {
 
 	require.Equal(t, uint(3), q2.Len())
 
-	op, l, err = q2.Remove(1)
+	removed, l, err = q2.Remove(1)
 	require.NoError(t, err)
 	require.Equal(t, uint(2), l)
-	require.Len(t, op, 1)
-	require.Equal(t, op2, op[0])
+	require.Equal(t, uint(1), removed)
 
-	op, l, err = q2.Remove(2)
+	removed, l, err = q2.Remove(2)
 	require.NoError(t, err)
 	require.Zero(t, l)
-	require.Len(t, op, 2)
-	require.Equal(t, op3, op[0])
-	require.Equal(t, op4, op[1])
+	require.Equal(t, uint(2), removed)
 
 	q2.Close()
 

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200517170823-9f98d46a0e0f
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.3

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -209,8 +209,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200517170823-9f98d46a0e0
 github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200517170823-9f98d46a0e0f/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3 h1:f426k4Txm1O7zKHLmgLJ9wkUn0nQBKR9fFoZDItEfSw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.3/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b h1:J3IcuMqP1uRKOXQ6EaMiVo5oPfSFpZaZM2MJ5JIQjig=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200519173902-cd4a2ee14c1b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15 h1:+s9KX+mJGo5mEm2IK9IwvmXGH9jtZgVq8xnNmnLQJ74=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200521210520-09fe36d37f15/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
The Remove function of the LevelDB operation queue no longer returns the removed operations - just the number of operations removed.

closes #324

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>