### PR TITLE
chore: Add namespace to Sidetree transaction

### DIFF
--- a/cmd/chaincode/txn/txn.go
+++ b/cmd/chaincode/txn/txn.go
@@ -184,7 +184,7 @@ func (cc *SidetreeTxnCC) anchorBatch(stub shim.ChaincodeStubInterface, args [][]
 	}
 
 	// record anchor file address on the ledger (Sidetree Transaction)
-	err = stub.PutState(common.AnchorAddrPrefix+anchorAddr, []byte(anchorAddr))
+	err = stub.PutState(common.AnchorPrefix+anchorAddr, []byte(anchorAddr))
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to write anchor address: %s", err.Error())
 		logger.Errorf("[txID %s] %s", txID, errMsg)
@@ -194,21 +194,22 @@ func (cc *SidetreeTxnCC) anchorBatch(stub shim.ChaincodeStubInterface, args [][]
 	return shim.Success(nil)
 }
 
-// writeAnchor will record anchor file address on the ledger
+// writeAnchor will record anchor info on the ledger
 func (cc *SidetreeTxnCC) writeAnchor(stub shim.ChaincodeStubInterface, args [][]byte) pb.Response {
 	txID := stub.GetTxID()
-	if len(args) != 1 || len(args[0]) == 0 {
-		errMsg := "missing anchor file address"
+	if len(args) != 2 || len(args[0]) == 0 || len(args[1]) == 0 {
+		errMsg := "missing anchor string and/or txn info"
 		logger.Debugf("[txID %s] %s", txID, errMsg)
 		return shim.Error(errMsg)
 	}
 
-	anchorAddr := string(args[0])
+	anchorString := string(args[0])
+	txnInfo := args[1]
 
-	// record anchor file address on the ledger (Sidetree Transaction)
-	err := stub.PutState(common.AnchorAddrPrefix+anchorAddr, []byte(anchorAddr))
+	// record anchor string on the ledger plus Sidetree transaction info (anchor string, namespace)
+	err := stub.PutState(common.AnchorPrefix+anchorString, txnInfo)
 	if err != nil {
-		errMsg := fmt.Sprintf("failed to write anchor address: %s", err.Error())
+		errMsg := fmt.Sprintf("failed to write anchor string: %s", err.Error())
 		logger.Errorf("[txID %s] %s", txID, errMsg)
 		return shim.Error(errMsg)
 	}

--- a/cmd/chaincode/txn/txn_test.go
+++ b/cmd/chaincode/txn/txn_test.go
@@ -128,24 +128,43 @@ func TestWriteAnchor(t *testing.T) {
 
 	stub := prepareStub()
 
-	anchorAddress := []byte("Addr")
-	payload, err := invoke(stub, [][]byte{[]byte(writeAnchor), anchorAddress})
+	anchor := []byte("anchor")
+	txnInfo := []byte("txn")
+	payload, err := invoke(stub, [][]byte{[]byte(writeAnchor), anchor, txnInfo})
 	require.Nil(t, err)
 	require.Nil(t, payload)
 
-	result, err := stub.GetState(common.AnchorAddrPrefix + string(anchorAddress))
+	result, err := stub.GetState(common.AnchorPrefix + string(anchor))
 	require.Nil(t, err)
-	require.Equal(t, anchorAddress, result)
+	require.Equal(t, txnInfo, result)
 }
 
-func TestWriteAnchor_MissingAnchorAddress(t *testing.T) {
-
+func TestWriteAnchor_CheckRequiredArguments(t *testing.T) {
 	stub := prepareStub()
 
-	payload, err := invoke(stub, [][]byte{[]byte(writeAnchor), []byte("")})
+	// missing args
+	payload, err := invoke(stub, [][]byte{[]byte(writeAnchor)})
 	require.NotNil(t, err)
 	require.Nil(t, payload)
-	require.Contains(t, err.Error(), "missing anchor file address")
+	require.Contains(t, err.Error(), "missing anchor string and/or txn info")
+
+	// empty anchor
+	payload, err = invoke(stub, [][]byte{[]byte(writeAnchor), []byte("")})
+	require.NotNil(t, err)
+	require.Nil(t, payload)
+	require.Contains(t, err.Error(), "missing anchor string and/or txn info")
+
+	// empty txn info
+	payload, err = invoke(stub, [][]byte{[]byte(writeAnchor), []byte("address"), []byte("")})
+	require.NotNil(t, err)
+	require.Nil(t, payload)
+	require.Contains(t, err.Error(), "missing anchor string and/or txn info")
+
+	// suc
+	payload, err = invoke(stub, [][]byte{[]byte(writeAnchor), []byte("address"), []byte("")})
+	require.NotNil(t, err)
+	require.Nil(t, payload)
+	require.Contains(t, err.Error(), "missing anchor string and/or txn info")
 }
 
 func TestAnchorBatch(t *testing.T) {
@@ -158,7 +177,7 @@ func TestAnchorBatch(t *testing.T) {
 	require.Nil(t, err)
 	require.Nil(t, payload)
 
-	result, err := stub.GetState(common.AnchorAddrPrefix + encodedSHA256Hash(anchor))
+	result, err := stub.GetState(common.AnchorPrefix + encodedSHA256Hash(anchor))
 	require.Nil(t, err)
 	require.Equal(t, string(result), encodedSHA256Hash(anchor))
 

--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -367,8 +367,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200605015306-f0d83470dceb
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200605015306-f0d83470dceb/go.mod h1:Ynw2zY6qe51PK742XymWYCYyU5RjLJzAlFxsZcgwCLs=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed h1:tfW25lJzJJxT7zCuk5YoMj7HcDFpWYcXY0pYNTFSrjQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7 h1:su6MhNSs7bl27pYSORj0yPAaxEVZTwtVXdPqbHPFLGk=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200605015306-f0d83470dceb
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200605015306-f0d83470dceb/go.mod h1:Ynw2zY6qe51PK742XymWYCYyU5RjLJzAlFxsZcgwCLs=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed h1:tfW25lJzJJxT7zCuk5YoMj7HcDFpWYcXY0pYNTFSrjQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7 h1:su6MhNSs7bl27pYSORj0yPAaxEVZTwtVXdPqbHPFLGk=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/context/blockchain/client_test.go
+++ b/pkg/context/blockchain/client_test.go
@@ -15,13 +15,14 @@ import (
 )
 
 const (
-	chID   = "mychannel"
-	ccName = "cc1"
+	chID      = "mychannel"
+	ccName    = "cc1"
+	namespace = "did:sidetree"
 )
 
 func TestNew(t *testing.T) {
 	txnProvider := &stmocks.TxnServiceProvider{}
-	c := New(chID, ccName, txnProvider)
+	c := New(chID, ccName, namespace, txnProvider)
 	require.NotNil(t, c)
 }
 
@@ -31,7 +32,7 @@ func TestGetClientError(t *testing.T) {
 	txnProvider := &stmocks.TxnServiceProvider{}
 	txnProvider.ForChannelReturns(nil, testErr)
 
-	c := New(chID, ccName, txnProvider)
+	c := New(chID, ccName, namespace, txnProvider)
 	require.NotNil(t, c)
 
 	err := c.WriteAnchor("anchor")
@@ -43,7 +44,7 @@ func TestWriteAnchor(t *testing.T) {
 	txnProvider := &stmocks.TxnServiceProvider{}
 	txnProvider.ForChannelReturns(txnService, nil)
 
-	c := New(chID, ccName, txnProvider)
+	c := New(chID, ccName, namespace, txnProvider)
 
 	err := c.WriteAnchor("anchor")
 	require.Nil(t, err)
@@ -58,7 +59,7 @@ func TestWriteAnchorError(t *testing.T) {
 
 	txnProvider := &stmocks.TxnServiceProvider{}
 	txnProvider.ForChannelReturns(txnService, nil)
-	bc := New(chID, ccName, txnProvider)
+	bc := New(chID, ccName, namespace, txnProvider)
 
 	err := bc.WriteAnchor("anchor")
 	require.NotNil(t, err)
@@ -68,7 +69,7 @@ func TestWriteAnchorError(t *testing.T) {
 func TestClient_Read(t *testing.T) {
 	require.PanicsWithValue(t, "not implemented", func() {
 		txnProvider := &stmocks.TxnServiceProvider{}
-		c := New(chID, ccName, txnProvider)
+		c := New(chID, ccName, namespace, txnProvider)
 		c.Read(1000)
 	})
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -61,7 +61,7 @@ func New(
 		namespace:        namespace,
 		protocolClient:   protocol.New(protocolVersions),
 		casClient:        cas.New(channelID, dcasCfg, dcasProvider),
-		blockchainClient: blockchain.New(channelID, dcasCfg.ChaincodeName, txnProvider),
+		blockchainClient: blockchain.New(channelID, dcasCfg.ChaincodeName, namespace, txnProvider),
 		opQueue:          opQueue,
 	}, nil
 }

--- a/pkg/observer/common/constants.go
+++ b/pkg/observer/common/constants.go
@@ -7,6 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package common
 
 const (
-	// AnchorAddrPrefix is the anchor address prefix that is used to persist anchors
-	AnchorAddrPrefix = "sidetreeanchor_"
+	// AnchorPrefix is the prefix that is that is used to persist anchors
+	AnchorPrefix = "sidetreeanchor_"
 )
+
+// TxnInfo contains info that gets recorded on blockchain as part of Sidetree transaction
+type TxnInfo struct {
+	AnchorString string `json:"anchor_string"`
+	Namespace    string `json:"namespace"`
+}

--- a/pkg/observer/notifier/notifier.go
+++ b/pkg/observer/notifier/notifier.go
@@ -51,7 +51,7 @@ func New(channelID string, bpProvider blockPublisherProvider, txnChan chan<- gos
 }
 
 func (n *Notifier) handleWrite(txMetadata gossipapi.TxMetadata, namespace string, kvWrite *kvrwset.KVWrite) error {
-	if kvWrite.IsDelete || !strings.HasPrefix(kvWrite.Key, common.AnchorAddrPrefix) {
+	if kvWrite.IsDelete || !strings.HasPrefix(kvWrite.Key, common.AnchorPrefix) {
 		return nil
 	}
 

--- a/pkg/observer/notifier/notifier_test.go
+++ b/pkg/observer/notifier/notifier_test.go
@@ -47,7 +47,7 @@ func TestRegisterForAnchorFileAddress(t *testing.T) {
 				}
 			}
 		}()
-		require.NoError(t, p.HandleWrite(gossipapi.TxMetadata{BlockNum: 1, ChannelID: testChannel, TxID: "tx1"}, sideTreeTxnCCName, &kvrwset.KVWrite{Key: common.AnchorAddrPrefix + k1, IsDelete: true, Value: []byte(v1)}))
+		require.NoError(t, p.HandleWrite(gossipapi.TxMetadata{BlockNum: 1, ChannelID: testChannel, TxID: "tx1"}, sideTreeTxnCCName, &kvrwset.KVWrite{Key: common.AnchorPrefix + k1, IsDelete: true, Value: []byte(v1)}))
 		result := <-done
 		require.Empty(t, result)
 	})
@@ -68,7 +68,7 @@ func TestRegisterForAnchorFileAddress(t *testing.T) {
 				}
 			}
 		}()
-		require.NoError(t, p.HandleWrite(gossipapi.TxMetadata{BlockNum: 1, ChannelID: testChannel, TxID: "tx1"}, sideTreeTxnCCName, &kvrwset.KVWrite{Key: common.AnchorAddrPrefix + k1, IsDelete: false, Value: []byte(v1)}))
+		require.NoError(t, p.HandleWrite(gossipapi.TxMetadata{BlockNum: 1, ChannelID: testChannel, TxID: "tx1"}, sideTreeTxnCCName, &kvrwset.KVWrite{Key: common.AnchorPrefix + k1, IsDelete: false, Value: []byte(v1)}))
 		result := <-done
 		require.Equal(t, uint64(1), result.BlockNum)
 	})

--- a/pkg/rest/blockchainhandler/blockchainscanner_test.go
+++ b/pkg/rest/blockchainhandler/blockchainscanner_test.go
@@ -23,11 +23,11 @@ func TestBlockchainScanner(t *testing.T) {
 	const blockNum = 1000
 	const txn1 = "tx1"
 	const txn2 = "tx2"
-	const anchor = "xxx"
+	const anchor = "1.anchor"
 
 	bb := mocks.NewBlockBuilder(channel1, blockNum)
-	bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor))
-	bb.Transaction(txn2, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor))
+	bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor))
+	bb.Transaction(txn2, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor))
 
 	bcInfo := &cb.BlockchainInfo{
 		Height: 2,

--- a/pkg/rest/blockchainhandler/firstValidScanner.go
+++ b/pkg/rest/blockchainhandler/firstValidScanner.go
@@ -124,8 +124,8 @@ func (v *txnValidator) isValid() (bool, error) {
 }
 
 func (v *txnValidator) handleWrite(w *blockvisitor.Write) error {
-	if !strings.HasPrefix(w.Write.Key, common.AnchorAddrPrefix) {
-		logger.Debugf("[%s] Ignoring write to namespace [%s] in block [%d] and TxNum [%d] since the key doesn't have the anchor address prefix [%s]", v.channelID, w.Namespace, w.BlockNum, w.TxNum, common.AnchorAddrPrefix)
+	if !strings.HasPrefix(w.Write.Key, common.AnchorPrefix) {
+		logger.Debugf("[%s] Ignoring write to namespace [%s] in block [%d] and TxNum [%d] since the key doesn't have the anchor address prefix [%s]", v.channelID, w.Namespace, w.BlockNum, w.TxNum, common.AnchorPrefix)
 
 		return nil
 	}
@@ -136,7 +136,11 @@ func (v *txnValidator) handleWrite(w *blockvisitor.Write) error {
 		return nil
 	}
 
-	anchorString := string(w.Write.Value)
+	anchorString, err := getAnchorString(w.Write.Value)
+	if err != nil {
+		return errors.WithMessagef(err, "failed to get anchor string [%s] in block [%d] and TxNum [%d]", w.Write.Key, w.BlockNum, w.TxNum)
+	}
+
 	if anchorString != v.desc.Transaction().AnchorString {
 		logger.Debugf("[%s] AnchorString [%s] for block [%d] and TxnNumber [%d] does not match the provided AnchorString [%s]", v.channelID, anchorString, v.desc.BlockNum(), v.desc.TxnNum(), v.desc.Transaction().AnchorString)
 

--- a/pkg/rest/blockchainhandler/firstvalidhandler_test.go
+++ b/pkg/rest/blockchainhandler/firstvalidhandler_test.go
@@ -53,9 +53,9 @@ func TestFirstValid_Handler(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor1))
-		bb.Transaction(txn2, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor2))
-		bb.Transaction(txn2, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor3))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor1))
+		bb.Transaction(txn2, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor2))
+		bb.Transaction(txn2, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor3))
 
 		block := bb.Build()
 		blockHash := base64.URLEncoding.EncodeToString(protoutil.BlockHeaderHash(block.Header))
@@ -107,7 +107,7 @@ func TestFirstValid_Handler(t *testing.T) {
 
 	t.Run("No valid transactions", func(t *testing.T) {
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor1))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor1))
 
 		block := bb.Build()
 		blockHash := base64.URLEncoding.EncodeToString(protoutil.BlockHeaderHash(block.Header))
@@ -181,7 +181,7 @@ func TestFirstValid_Handler(t *testing.T) {
 
 	t.Run("Marshal error", func(t *testing.T) {
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor1))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor1))
 
 		block := bb.Build()
 		blockHash := base64.URLEncoding.EncodeToString(protoutil.BlockHeaderHash(block.Header))

--- a/pkg/rest/blockchainhandler/transactionshandler_test.go
+++ b/pkg/rest/blockchainhandler/transactionshandler_test.go
@@ -63,7 +63,7 @@ func TestTransactions_All(t *testing.T) {
 		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
 
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor))
 		bcClient.GetBlockByNumberReturns(bb.Build(), nil)
 
 		bcProvider.ForChannelReturns(bcClient, nil)
@@ -88,7 +88,7 @@ func TestTransactions_All(t *testing.T) {
 		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
 
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor))
 		bcClient.GetBlockByNumberReturns(bb.Build(), nil)
 
 		bcProvider.ForChannelReturns(bcClient, nil)
@@ -114,7 +114,7 @@ func TestTransactions_All(t *testing.T) {
 		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
 
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor))
 		bcClient.GetBlockByNumberReturns(bb.Build(), nil)
 
 		bcProvider.ForChannelReturns(bcClient, nil)
@@ -191,7 +191,7 @@ func TestTransactions_Since(t *testing.T) {
 		defer restoreParams()
 
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor))
 
 		bcClient := &obmocks.BlockchainClient{}
 		bcClient.GetBlockchainInfoReturns(bcInfo, nil)
@@ -323,7 +323,7 @@ func TestTransactions_Since(t *testing.T) {
 		defer restoreParams()
 
 		bb := mocks.NewBlockBuilder(channel1, blockNum)
-		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorAddrPrefix, []byte(anchor))
+		bb.Transaction(txn1, pb.TxValidationCode_VALID).ChaincodeAction("sidetree").Write(common.AnchorPrefix, getTxnInfo(anchor))
 
 		errExpected := errors.New("injected blockchain client error")
 		bcClient := &obmocks.BlockchainClient{}

--- a/test/bddtests/features/blockchain-handler.feature
+++ b/test/bddtests/features/blockchain-handler.feature
@@ -148,10 +148,10 @@ Feature:
     Then the JSON path "#" of the response has 2 items
     And the JSON path "0.header.number" of the response equals "${time_0}"
     And the JSON path "1.header.previous_hash" of the response is saved to variable "previous-hash"
-    And the JSON path "1.data.data.0.payload.data.actions.0.payload.action.proposal_response_payload.extension.results.ns_rwset.2.rwset.writes.0.value" of the response is saved to variable "anchor-string"
+    And the JSON path "1.data.data.0.payload.data.actions.0.payload.action.proposal_response_payload.extension.results.ns_rwset.2.rwset.writes.0.value" of the response is saved to variable "txn-info"
     # Binary values in the JSON block are returned as strings encoded in base64 (standard) encoding. Decoding the value will give us the (base64URL-encoded) anchor string.
-    Given the base64-encoded value "${anchor-string}" is decoded and saved to variable "url-encoded-anchor-string"
-    And anchor address is parsed from anchor string "url-encoded-anchor-string" and saved to variable "url-encoded-anchor-address"
+    Given the base64-encoded value "${txn-info}" is decoded and saved to variable "url-encoded-txn-info"
+    And anchor address is parsed from transaction info "url-encoded-txn-info" and saved to variable "url-encoded-anchor-address"
     # Retrieve the anchor file from DCAS
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${url-encoded-anchor-address}?max-size=1000000"
     Then the JSON path "mapFileHash" of the response is not empty
@@ -164,20 +164,21 @@ Feature:
 
     # Retrieve the anchor file from the current block hash
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/blocks/${latest-hash}"
-    Then the JSON path "0.data.data.0.payload.data.actions.0.payload.action.proposal_response_payload.extension.results.ns_rwset.2.rwset.writes.0.value" of the response is saved to variable "anchor-string"
+    Then the JSON path "0.data.data.0.payload.data.actions.0.payload.action.proposal_response_payload.extension.results.ns_rwset.2.rwset.writes.0.value" of the response is saved to variable "txn-info"
     # Binary values in the JSON block are returned as strings encoded in base64 (standard) encoding. Decoding the value will give us the (base64URL-encoded) anchor string.
-    Given the base64-encoded value "${anchor-string}" is decoded and saved to variable "url-encoded-anchor-string"
-    And anchor address is parsed from anchor string "url-encoded-anchor-string" and saved to variable "url-encoded-anchor-address"
+    Given the base64-encoded value "${txn-info}" is decoded and saved to variable "url-encoded-txn-info"
+    And anchor address is parsed from transaction info "url-encoded-txn-info" and saved to variable "url-encoded-anchor-address"
+
     # Retrieve the anchor file from DCAS
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${url-encoded-anchor-address}?max-size=1000000"
     Then the JSON path "mapFileHash" of the response is not empty
 
     # Retrieve the anchor file from the previous block hash
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/blockchain/blocks/${latest-previous-hash}"
-    Then the JSON path "0.data.data.0.payload.data.actions.0.payload.action.proposal_response_payload.extension.results.ns_rwset.2.rwset.writes.0.value" of the response is saved to variable "anchor-string"
+    Then the JSON path "0.data.data.0.payload.data.actions.0.payload.action.proposal_response_payload.extension.results.ns_rwset.2.rwset.writes.0.value" of the response is saved to variable "txn-info"
     # Binary values in the JSON block are returned as strings encoded in base64 (standard) encoding. Decoding the value will give us the (base64URL-encoded) anchor string.
-    Given the base64-encoded value "${anchor-string}" is decoded and saved to variable "url-encoded-anchor-string"
-    And anchor address is parsed from anchor string "url-encoded-anchor-string" and saved to variable "url-encoded-anchor-address"
+    Given the base64-encoded value "${txn-info}" is decoded and saved to variable "url-encoded-txn-info"
+    And anchor address is parsed from transaction info "url-encoded-txn-info" and saved to variable "url-encoded-anchor-address"
     # Retrieve the anchor file from DCAS
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${url-encoded-anchor-address}?max-size=1000000"
     Then the JSON path "mapFileHash" of the response is not empty

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200603180039-ec1ce6c38dc1
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 )
 

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -209,8 +209,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200603180039-ec1ce6c38dc
 github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200603180039-ec1ce6c38dc1/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed h1:tfW25lJzJJxT7zCuk5YoMj7HcDFpWYcXY0pYNTFSrjQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200603131611-12bccb6926ed/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7 h1:su6MhNSs7bl27pYSORj0yPAaxEVZTwtVXdPqbHPFLGk=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200605130300-d78c5494b4d7/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Updated:
-- blockchain client to include namespace during transaction
-- txn cc to include additional parameter
-- observer to parse transaction info
-- rest api to parse transaction info

Closes #338

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>