### PR TITLE
chore: update sidetree core (commitment changes)

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -370,8 +370,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200611121248-9e2fe4405019
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200611121248-9e2fe4405019/go.mod h1:J1wple5XYUTm64Y7kdH1AUYZzdhCpPY4cbWJK+QiwPM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b h1:7s3Vq39k3lI0P6q3SccW6un3Sbk04lbRYo5bzzLMVsQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07 h1:W0LTy0UdxiDjg65TH/4wS7J5pAv+HSZGl6gsOqwk0g8=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/stretchr/testify v1.4.0
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200604234820-c9c017a66039

--- a/go.sum
+++ b/go.sum
@@ -381,8 +381,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200611121248-9e2fe4405019
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200611121248-9e2fe4405019/go.mod h1:J1wple5XYUTm64Y7kdH1AUYZzdhCpPY4cbWJK+QiwPM=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b h1:7s3Vq39k3lI0P6q3SccW6un3Sbk04lbRYo5bzzLMVsQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07 h1:W0LTy0UdxiDjg65TH/4wS7J5pAv+HSZGl6gsOqwk0g8=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
@@ -287,15 +288,24 @@ func getID(code uint, content []byte) (string, error) {
 }
 
 func getCreateRequest() ([]byte, error) {
-	info := &helper.CreateRequestInfo{
-		OpaqueDocument: validDoc,
-		RecoveryKey: &jws.JWK{
-			Kty: "kty",
-			Crv: "crv",
-			X:   "x",
-		},
-		MultihashCode: sha2_256,
+	testKey := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
 	}
+
+	c, err := commitment.Calculate(testKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
+	info := &helper.CreateRequestInfo{
+		OpaqueDocument:     validDoc,
+		RecoveryCommitment: c,
+		UpdateCommitment:   c,
+		MultihashCode:      sha2_256,
+	}
+
 	return helper.NewCreateRequest(info)
 }
 

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -114,7 +114,7 @@ func New(channelID string, peerCfg peerConfig, observerCfg config.Observer, dcas
 			&observer.Providers{
 				TxnOpsProvider:   txnhandler.NewOperationProvider(dcasReader, pcp, compressionProvider),
 				OpStoreProvider:  asObserverStoreProvider(opStoreProvider),
-				OpFilterProvider: operationfilter.NewProvider(channelID, opStoreProvider),
+				OpFilterProvider: operationfilter.NewProvider(channelID, opStoreProvider, pcp),
 			},
 		),
 		txnChan:     txnChan,

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -9,6 +9,7 @@ package observer
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"testing"
 	"time"
 
@@ -602,14 +603,22 @@ func getTestOperations(createOpsNum int) ([]*batch.Operation, error) {
 }
 
 func generateCreateOperations(num int) (*batch.Operation, error) {
+	testKey := &jws.JWK{
+		Crv: "crv",
+		Kty: "kty",
+		X:   "x",
+	}
+
+	c, err := commitment.Calculate(testKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	doc := fmt.Sprintf(`{"test":%d}`, num)
 	info := &helper.CreateRequestInfo{OpaqueDocument: doc,
-		RecoveryKey: &jws.JWK{
-			Crv: "crv",
-			Kty: "kty",
-			X:   "x",
-		},
-		MultihashCode: sha2_256}
+		RecoveryCommitment: c,
+		UpdateCommitment:   c,
+		MultihashCode:      sha2_256}
 
 	request, err := helper.NewCreateRequest(info)
 	if err != nil {

--- a/pkg/observer/operationfilter/operationfilter.go
+++ b/pkg/observer/operationfilter/operationfilter.go
@@ -9,7 +9,6 @@ package operationfilter
 import (
 	sidetreeobserver "github.com/trustbloc/sidetree-core-go/pkg/observer"
 	"github.com/trustbloc/sidetree-core-go/pkg/processor"
-
 	"github.com/trustbloc/sidetree-fabric/pkg/context/common"
 )
 
@@ -17,13 +16,15 @@ import (
 type Provider struct {
 	channelID       string
 	opStoreProvider common.OperationStoreProvider
+	pcp             common.ProtocolClientProvider
 }
 
 // NewProvider returns a new operation filter provider
-func NewProvider(channelID string, opStoreProvider common.OperationStoreProvider) *Provider {
+func NewProvider(channelID string, opStoreProvider common.OperationStoreProvider, pcp common.ProtocolClientProvider) *Provider {
 	return &Provider{
 		channelID:       channelID,
 		opStoreProvider: opStoreProvider,
+		pcp:             pcp,
 	}
 }
 
@@ -34,5 +35,10 @@ func (f *Provider) Get(namespace string) (sidetreeobserver.OperationFilter, erro
 		return nil, err
 	}
 
-	return processor.NewOperationFilter(f.channelID+"_"+namespace, opStore), nil
+	pc, err := f.pcp.ForNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	return processor.NewOperationFilter(f.channelID+"_"+namespace, opStore, pc), nil
 }

--- a/pkg/observer/operationfilter/operationfilter_test.go
+++ b/pkg/observer/operationfilter/operationfilter_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/trustbloc/sidetree-fabric/pkg/mocks"
+
+	coremocks "github.com/trustbloc/sidetree-core-go/pkg/mocks"
 )
 
 const (
@@ -22,9 +24,13 @@ const (
 )
 
 func TestProvider(t *testing.T) {
+	pcp := coremocks.NewMockProtocolClientProvider()
+	pcp.ProtocolClients[ns1] = coremocks.NewMockProtocolClient()
+	pcp.ProtocolClients[ns2] = coremocks.NewMockProtocolClient()
+
 	opStoreProvider := &mocks.OperationStoreProvider{}
 
-	p := NewProvider(channel1, opStoreProvider)
+	p := NewProvider(channel1, opStoreProvider, pcp)
 	require.NotNil(t, p)
 
 	s1, err := p.Get(ns1)
@@ -40,15 +46,29 @@ func TestProvider(t *testing.T) {
 	require.Equal(t, s2, s3)
 }
 
-func TestProviderError(t *testing.T) {
+func TestStoreProviderError(t *testing.T) {
 	errExpected := errors.New("injected op store provider error")
 	opStoreProvider := &mocks.OperationStoreProvider{}
 	opStoreProvider.ForNamespaceReturns(nil, errExpected)
 
-	p := NewProvider(channel1, opStoreProvider)
+	pcp := coremocks.NewMockProtocolClientProvider()
+
+	p := NewProvider(channel1, opStoreProvider, pcp)
 	require.NotNil(t, p)
 
 	s, err := p.Get(ns1)
 	require.EqualError(t, err, errExpected.Error())
+	require.Nil(t, s)
+}
+
+func TestProtocolProviderError(t *testing.T) {
+	opStoreProvider := &mocks.OperationStoreProvider{}
+	pcp := coremocks.NewMockProtocolClientProvider()
+
+	p := NewProvider(channel1, opStoreProvider, pcp)
+	require.NotNil(t, p)
+
+	s, err := p.Get(ns1)
+	require.Contains(t, err.Error(), "protocol client not found for namespace")
 	require.Nil(t, s)
 }

--- a/pkg/peer/sidetreesvc/restsvc.go
+++ b/pkg/peer/sidetreesvc/restsvc.go
@@ -113,7 +113,7 @@ func newRESTHandlers(
 		protocolProvider.Protocol(),
 		getValidator(opStore),
 		batchWriter,
-		processor.New(channelID+"_"+cfg.Namespace, opStore),
+		processor.New(channelID+"_"+cfg.Namespace, opStore, protocolProvider.Protocol()),
 	)
 
 	service := newService(cfg.Namespace, apiVersion, cfg.BasePath)

--- a/pkg/rest/filehandler/validator_test.go
+++ b/pkg/rest/filehandler/validator_test.go
@@ -162,13 +162,12 @@ func TestDocumentValidator_TransformDocument(t *testing.T) {
 		require.Equal(t, doc, transformed.Document)
 	})
 
-	t.Run("document with operation keys", func(t *testing.T) {
-		doc, err := document.FromBytes([]byte(validDocWithOpsKeysOnly))
+	t.Run("document with no keys", func(t *testing.T) {
+		doc, err := document.FromBytes([]byte(validDocNoKeys))
 		require.NoError(t, err)
 
 		result, err := v.TransformDocument(doc)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(result.MethodMetadata.OperationPublicKeys))
 
 		jsonTransformed, err := json.Marshal(result.Document)
 		require.NoError(t, err)
@@ -177,20 +176,19 @@ func TestDocumentValidator_TransformDocument(t *testing.T) {
 		require.Equal(t, 0, len(didDoc.PublicKeys()))
 	})
 
-	t.Run("document with mixed operation and general keys", func(t *testing.T) {
+	t.Run("document with two general keys", func(t *testing.T) {
 		// most likely this scenario will not be used
-		doc, err := document.FromBytes([]byte(validDocWithMixedKeys))
+		doc, err := document.FromBytes([]byte(validDocWithKeys))
 		require.NoError(t, err)
 
 		result, err := v.TransformDocument(doc)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(result.MethodMetadata.OperationPublicKeys))
 
 		jsonTransformed, err := json.Marshal(result.Document)
 		require.NoError(t, err)
 		didDoc, err := document.DidDocumentFromBytes(jsonTransformed)
 		require.NoError(t, err)
-		require.Equal(t, 1, len(didDoc.PublicKeys()))
+		require.Equal(t, 2, len(didDoc.PublicKeys()))
 	})
 }
 
@@ -297,22 +295,9 @@ func newJSONPatch(patches string) (patch.Patch, error) {
 	return p, nil
 }
 
-const validDocWithOpsKeysOnly = `
+const validDocNoKeys = `
 {
   "id" : "doc:method:abc",
-  "publicKey": [
-    {
-      "id": "update-key",
-      "type": "JwsVerificationKey2020",
-      "usage": ["ops"],
-      "jwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    }
-  ],
   "other": [
     {
       "name": "name"
@@ -320,14 +305,15 @@ const validDocWithOpsKeysOnly = `
   ]
 }`
 
-const validDocWithMixedKeys = `
+// TODO: Revisit if keys are needed for generic documents
+const validDocWithKeys = `
 {
   "id" : "doc:method:abc",
   "publicKey": [
     {
-      "id": "update-key",
+      "id": "auth-key",
       "type": "JwsVerificationKey2020",
-      "usage": ["ops"],
+      "usage": ["general"],
       "jwk": {
         "kty": "EC",
         "crv": "P-256K",

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.3.0
 	github.com/spf13/viper v1.3.2
 	github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200603180039-ec1ce6c38dc1
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 )
 

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -209,8 +209,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200603180039-ec1ce6c38dc
 github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200603180039-ec1ce6c38dc1/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131 h1:RYHsugONyKaDjnqdVSPXNa/wxPEY2csnqWnyOcGsq44=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200529174943-b277c62ed131/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b h1:7s3Vq39k3lI0P6q3SccW6un3Sbk04lbRYo5bzzLMVsQ=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200611192858-0b6850315a8b/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07 h1:W0LTy0UdxiDjg65TH/4wS7J5pAv+HSZGl6gsOqwk0g8=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200618140809-f15d6a446d07/go.mod h1:xCuMVdRtXiCghr58Dcd1RW9t0lCDXPPjkSiACzKGaZc=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Sidetree core has been updated:
- generate recovery and update commitments from corresponding public JWK during create
- add update key to update request
- add recovery key for deactivate and recover requests
- validate keys against previously provided commitments
- validate signature against passed in keys
- return update and recovery commitments in resolution result metadata (remove recovery key and operation keys)

Closes #348

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>