### PR TITLE
chore: Update sidetree-core (get protocol by txn number)

### DIFF
--- a/cmd/chaincode/cas/client_test.go
+++ b/cmd/chaincode/cas/client_test.go
@@ -91,7 +91,7 @@ func TestRead(t *testing.T) {
 }
 
 func TestQuery(t *testing.T) {
-	const query = "{\"selector\":{\"id\":\"1234\"},\"use_index\":[\"_design/indexIDDoc\",\"indexID\"]}"
+	const query = "{\"selector\":{\"uniqueSuffix\":\"1234\"},\"use_index\":[\"_design/indexUniqueSuffixDoc\",\"indexUniqueSuffix\"]}"
 
 	client := getClient()
 
@@ -176,11 +176,11 @@ func getOperationBytes(op *Operation) []byte {
 }
 
 func getCreateOperation() *Operation {
-	return &Operation{ID: "abc", Type: "create"}
+	return &Operation{UniqueSuffix: "abc", Type: "create"}
 }
 
 // Operation defines sample operation
 type Operation struct {
-	Type string `json:"type"`
-	ID   string `json:"id"`
+	Type         string `json:"type"`
+	UniqueSuffix string `json:"uniqueSuffix"`
 }

--- a/cmd/chaincode/doc/doc.go
+++ b/cmd/chaincode/doc/doc.go
@@ -21,7 +21,7 @@ const (
 	ccVersion = "v1"
 
 	couchDB       = "couchdb"
-	docsCollIndex = `{"index": {"fields": ["id"]}, "ddoc": "indexIDDoc", "name": "indexID", "type": "json"}`
+	docsCollIndex = `{"index": {"fields": ["uniqueSuffix"]}, "ddoc": "indexUniqueSuffixDoc", "name": "indexUniqueSuffix", "type": "json"}`
 )
 
 // DocumentCC is used to setup database, collection and indexes for documents
@@ -58,7 +58,7 @@ func (cc *DocumentCC) GetDBArtifacts(collNames []string) map[string]*ccapi.DBArt
 		collIndexes[collName] = []string{docsCollIndex}
 	}
 
-	logger.Debugf("Returning DB indexes for collections %s: %s", collNames, collIndexes)
+	logger.Infof("Returning DB indexes for collections %s: %s", collNames, collIndexes)
 
 	return map[string]*ccapi.DBArtifacts{
 		couchDB: {

--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -489,8 +489,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200717174601-9033a352298f
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200717174601-9033a352298f/go.mod h1:9D13etBW/6J4Bftt3msjRghZJV4FxL4ZBZgq7zy1GLs=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3 h1:IN4/w6vpZDTyrTwxkS10+nxCICtT+bFC9SI7Xd+AkLU=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da h1:WeCXxLZ3/WJCeOZo7WqVmG2xAni8+ikvT3/4X7L/1+g=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200717170638-8a06883825cf

--- a/go.sum
+++ b/go.sum
@@ -500,8 +500,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200717174601-9033a352298f
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200717174601-9033a352298f/go.mod h1:9D13etBW/6J4Bftt3msjRghZJV4FxL4ZBZgq7zy1GLs=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3 h1:IN4/w6vpZDTyrTwxkS10+nxCICtT+bFC9SI7Xd+AkLU=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da h1:WeCXxLZ3/WJCeOZo7WqVmG2xAni8+ikvT3/4X7L/1+g=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/context/protocol/client.go
+++ b/pkg/context/protocol/client.go
@@ -7,10 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package protocol
 
 import (
+	"fmt"
 	"sort"
+
+	"github.com/hyperledger/fabric/common/flogging"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 )
+
+var logger = flogging.MustGetLogger("protocol_client")
 
 // Client is a struct which holds a list of protocols.
 type Client struct {
@@ -36,4 +41,17 @@ func New(protocolVersions map[string]protocol.Protocol) *Client {
 //Current returns the latest version of protocol
 func (c *Client) Current() protocol.Protocol {
 	return c.protocols[len(c.protocols)-1]
+}
+
+// Get gets protocol version based on blockchain(transaction) time
+func (c *Client) Get(transactionTime uint64) (protocol.Protocol, error) {
+	logger.Debugf("available protocols: %v", c.protocols)
+
+	for i := len(c.protocols) - 1; i >= 0; i-- {
+		if transactionTime >= c.protocols[i].StartingBlockChainTime {
+			return c.protocols[i], nil
+		}
+	}
+
+	return protocol.Protocol{}, fmt.Errorf("protocol parameters are not defined for blockchain time: %d", transactionTime)
 }

--- a/pkg/context/protocol/client_test.go
+++ b/pkg/context/protocol/client_test.go
@@ -19,7 +19,7 @@ func TestNew(t *testing.T) {
 	require.NotNil(t, client)
 }
 
-func TestCurrentProtocol(t *testing.T) {
+func TestClient_Current(t *testing.T) {
 	versions := map[string]protocol.Protocol{
 		"1.0": {
 			StartingBlockChainTime:       500000,
@@ -40,4 +40,40 @@ func TestCurrentProtocol(t *testing.T) {
 
 	protocol := client.Current()
 	require.Equal(t, uint(10000), protocol.MaxOperationsPerBatch)
+}
+
+func TestClient_Get(t *testing.T) {
+	versions := map[string]protocol.Protocol{
+		"1.0": {
+			StartingBlockChainTime:       500000,
+			HashAlgorithmInMultiHashCode: 18,
+			MaxDeltaByteSize:             2000,
+			MaxOperationsPerBatch:        10000,
+		},
+		"0.1": {
+			StartingBlockChainTime:       10,
+			HashAlgorithmInMultiHashCode: 18,
+			MaxDeltaByteSize:             500,
+			MaxOperationsPerBatch:        100,
+		},
+	}
+
+	client := New(versions)
+	require.NotNil(t, client)
+
+	protocol, err := client.Get(100)
+	require.NoError(t, err)
+	require.Equal(t, uint(100), protocol.MaxOperationsPerBatch)
+
+	protocol, err = client.Get(500000)
+	require.NoError(t, err)
+	require.Equal(t, uint(10000), protocol.MaxOperationsPerBatch)
+
+	protocol, err = client.Get(7000000)
+	require.NoError(t, err)
+	require.Equal(t, uint(10000), protocol.MaxOperationsPerBatch)
+
+	protocol, err = client.Get(5)
+	require.Error(t, err)
+	require.Equal(t, err.Error(), "protocol parameters are not defined for blockchain time: 5")
 }

--- a/pkg/context/store/client.go
+++ b/pkg/context/store/client.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	queryByUniqueSuffixTemplate = `{"selector":{"uniqueSuffix":"%s"},"use_index":["_design/indexIDDoc","indexID"],"fields":["uniqueSuffix","type","encodedDelta","signedData","encodedSuffixData","transactionTime","transactionNumber","operationIndex"]}`
+	queryByUniqueSuffixTemplate = `{"selector":{"uniqueSuffix":"%s"},"use_index":["_design/indexUniqueSuffixDoc","indexUniqueSuffix"],"fields":["uniqueSuffix","type","encodedDelta","signedData","encodedSuffixData","transactionTime","transactionNumber","operationIndex"]}`
 )
 
 var logger = flogging.MustGetLogger("sidetree_context")

--- a/pkg/peer/config/service_test.go
+++ b/pkg/peer/config/service_test.go
@@ -101,14 +101,14 @@ func TestNewSidetreeProvider(t *testing.T) {
 
 		protocol4, ok := protocols[v0_4]
 		require.True(t, ok)
-		require.Equal(t, uint(200000), protocol4.StartingBlockChainTime)
+		require.Equal(t, uint64(200000), protocol4.StartingBlockChainTime)
 		require.Equal(t, uint(18), protocol4.HashAlgorithmInMultiHashCode)
 		require.Equal(t, uint(2000), protocol4.MaxDeltaByteSize)
 		require.Equal(t, uint(10), protocol4.MaxOperationsPerBatch)
 
 		protocol5, ok := protocols[v0_5]
 		require.True(t, ok)
-		require.Equal(t, uint(500000), protocol5.StartingBlockChainTime)
+		require.Equal(t, uint64(500000), protocol5.StartingBlockChainTime)
 		require.Equal(t, uint(18), protocol5.HashAlgorithmInMultiHashCode)
 		require.Equal(t, uint(10000), protocol5.MaxDeltaByteSize)
 		require.Equal(t, uint(100), protocol5.MaxOperationsPerBatch)

--- a/pkg/peer/mocks/protocolclient.gen.go
+++ b/pkg/peer/mocks/protocolclient.gen.go
@@ -10,12 +10,26 @@ import (
 type ProtocolClient struct {
 	CurrentStub        func() protocol.Protocol
 	currentMutex       sync.RWMutex
-	currentArgsForCall []struct{}
-	currentReturns     struct {
+	currentArgsForCall []struct {
+	}
+	currentReturns struct {
 		result1 protocol.Protocol
 	}
 	currentReturnsOnCall map[int]struct {
 		result1 protocol.Protocol
+	}
+	GetStub        func(uint64) (protocol.Protocol, error)
+	getMutex       sync.RWMutex
+	getArgsForCall []struct {
+		arg1 uint64
+	}
+	getReturns struct {
+		result1 protocol.Protocol
+		result2 error
+	}
+	getReturnsOnCall map[int]struct {
+		result1 protocol.Protocol
+		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
@@ -24,7 +38,8 @@ type ProtocolClient struct {
 func (fake *ProtocolClient) Current() protocol.Protocol {
 	fake.currentMutex.Lock()
 	ret, specificReturn := fake.currentReturnsOnCall[len(fake.currentArgsForCall)]
-	fake.currentArgsForCall = append(fake.currentArgsForCall, struct{}{})
+	fake.currentArgsForCall = append(fake.currentArgsForCall, struct {
+	}{})
 	fake.recordInvocation("Current", []interface{}{})
 	fake.currentMutex.Unlock()
 	if fake.CurrentStub != nil {
@@ -33,7 +48,8 @@ func (fake *ProtocolClient) Current() protocol.Protocol {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.currentReturns.result1
+	fakeReturns := fake.currentReturns
+	return fakeReturns.result1
 }
 
 func (fake *ProtocolClient) CurrentCallCount() int {
@@ -42,7 +58,15 @@ func (fake *ProtocolClient) CurrentCallCount() int {
 	return len(fake.currentArgsForCall)
 }
 
+func (fake *ProtocolClient) CurrentCalls(stub func() protocol.Protocol) {
+	fake.currentMutex.Lock()
+	defer fake.currentMutex.Unlock()
+	fake.CurrentStub = stub
+}
+
 func (fake *ProtocolClient) CurrentReturns(result1 protocol.Protocol) {
+	fake.currentMutex.Lock()
+	defer fake.currentMutex.Unlock()
 	fake.CurrentStub = nil
 	fake.currentReturns = struct {
 		result1 protocol.Protocol
@@ -50,6 +74,8 @@ func (fake *ProtocolClient) CurrentReturns(result1 protocol.Protocol) {
 }
 
 func (fake *ProtocolClient) CurrentReturnsOnCall(i int, result1 protocol.Protocol) {
+	fake.currentMutex.Lock()
+	defer fake.currentMutex.Unlock()
 	fake.CurrentStub = nil
 	if fake.currentReturnsOnCall == nil {
 		fake.currentReturnsOnCall = make(map[int]struct {
@@ -61,11 +87,76 @@ func (fake *ProtocolClient) CurrentReturnsOnCall(i int, result1 protocol.Protoco
 	}{result1}
 }
 
+func (fake *ProtocolClient) Get(arg1 uint64) (protocol.Protocol, error) {
+	fake.getMutex.Lock()
+	ret, specificReturn := fake.getReturnsOnCall[len(fake.getArgsForCall)]
+	fake.getArgsForCall = append(fake.getArgsForCall, struct {
+		arg1 uint64
+	}{arg1})
+	fake.recordInvocation("Get", []interface{}{arg1})
+	fake.getMutex.Unlock()
+	if fake.GetStub != nil {
+		return fake.GetStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *ProtocolClient) GetCallCount() int {
+	fake.getMutex.RLock()
+	defer fake.getMutex.RUnlock()
+	return len(fake.getArgsForCall)
+}
+
+func (fake *ProtocolClient) GetCalls(stub func(uint64) (protocol.Protocol, error)) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = stub
+}
+
+func (fake *ProtocolClient) GetArgsForCall(i int) uint64 {
+	fake.getMutex.RLock()
+	defer fake.getMutex.RUnlock()
+	argsForCall := fake.getArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *ProtocolClient) GetReturns(result1 protocol.Protocol, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = nil
+	fake.getReturns = struct {
+		result1 protocol.Protocol
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *ProtocolClient) GetReturnsOnCall(i int, result1 protocol.Protocol, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = nil
+	if fake.getReturnsOnCall == nil {
+		fake.getReturnsOnCall = make(map[int]struct {
+			result1 protocol.Protocol
+			result2 error
+		})
+	}
+	fake.getReturnsOnCall[i] = struct {
+		result1 protocol.Protocol
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *ProtocolClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
 	fake.currentMutex.RLock()
 	defer fake.currentMutex.RUnlock()
+	fake.getMutex.RLock()
+	defer fake.getMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/test/bddtests/fixtures/config/client/protocol.json
+++ b/test/bddtests/fixtures/config/client/protocol.json
@@ -1,6 +1,6 @@
 {
   "1.0": {
-    "startingBlockchainTime": 500000,
+    "startingBlockchainTime": 1,
     "hashAlgorithmInMultihashCode": 18,
     "maxDeltaByteSize": 200000,
     "maxOperationsPerBatch": 10,

--- a/test/bddtests/fixtures/config/fabric/mychannel-consortium-config.json
+++ b/test/bddtests/fixtures/config/fabric/mychannel-consortium-config.json
@@ -39,6 +39,13 @@
       "Components": [
         {
           "Name": "protocol",
+          "Version": "0.4",
+          "Config": "file://./sidetree-protocol-v0_4.json",
+          "Format": "json",
+          "Tags": ["sidetree"]
+        },
+        {
+          "Name": "protocol",
           "Version": "0.5",
           "Config": "file://./sidetree-protocol-v0_5.json",
           "Format": "json",
@@ -53,6 +60,13 @@
       "Config": "file://./file-server-config.yaml",
       "Format": "yaml",
       "Components": [
+        {
+          "Name": "protocol",
+          "Version": "0.4",
+          "Config": "file://./sidetree-protocol-v0_4.json",
+          "Format": "json",
+          "Tags": ["sidetree"]
+        },
         {
           "Name": "protocol",
           "Version": "0.5",

--- a/test/bddtests/fixtures/config/fabric/yourchannel-consortium-config.json
+++ b/test/bddtests/fixtures/config/fabric/yourchannel-consortium-config.json
@@ -16,6 +16,13 @@
       "Components": [
         {
           "Name": "protocol",
+          "Version": "0.4",
+          "Config": "file://./sidetree-protocol-v0_4.json",
+          "Format": "json",
+          "Tags": ["sidetree"]
+        },
+        {
+          "Name": "protocol",
           "Version": "0.5",
           "Config": "file://./sidetree-protocol-v0_5.json",
           "Format": "json",

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200625144512-dcb0ca18d43d
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -272,8 +272,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200625144512-dcb0ca18d43
 github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200625144512-dcb0ca18d43d/go.mod h1:LgoI0ccSEwewDjlxkI2yBQQUbu76Mdy4wFyylhOozUY=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3 h1:IN4/w6vpZDTyrTwxkS10+nxCICtT+bFC9SI7Xd+AkLU=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200720163951-97e8fe7645c3/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da h1:WeCXxLZ3/WJCeOZo7WqVmG2xAni8+ikvT3/4X7L/1+g=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200722185334-8fdfdf4b36da/go.mod h1:7iJd3MI8qlR+Fh80eGt9x5xofSGjAPN+022pUMdzhSY=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/vishvananda/netlink v1.0.0 h1:bqNY2lgheFIu1meHUFSH3d7vG93AFyqg3oGbJCOJgSM=
 github.com/vishvananda/netlink v1.0.0/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=


### PR DESCRIPTION
Sidetree core updates:
- add function to retrieve protocol by transaction (block) number

Add implementation of this function to fabric protocol client.

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>