### PR TITLE
test: Switch BDD test to Fabric 2 capabilities

### DIFF
--- a/test/bddtests/features/blockchain-handler.feature
+++ b/test/bddtests/features/blockchain-handler.feature
@@ -22,9 +22,9 @@ Feature:
     # Give the peers some time to gossip their new channel membership
     And we wait 20 seconds
 
-    And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
-    And "system" chaincode "document" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
+    Then chaincode "configscc", version "v1", package ID "configscc:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy ""
+    And chaincode "sidetreetxn", version "v1", package ID "sidetreetxn:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy "dcas-cfg"
+    And chaincode "document", version "v1", package ID "document:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" and collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed

--- a/test/bddtests/features/dcas-handler.feature
+++ b/test/bddtests/features/dcas-handler.feature
@@ -18,8 +18,8 @@ Feature:
     # Give the peers some time to gossip their new channel membership
     And we wait 20 seconds
 
-    And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
+    Then chaincode "configscc", version "v1", package ID "configscc:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy ""
+    And chaincode "sidetreetxn", version "v1", package ID "sidetreetxn:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy "dcas-cfg"
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -22,13 +22,13 @@ Feature:
     # Give the peers some time to gossip their new channel membership
     And we wait 20 seconds
 
-    And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
-    And "system" chaincode "document" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
+    Then chaincode "configscc", version "v1", package ID "configscc:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy ""
+    And chaincode "sidetreetxn", version "v1", package ID "sidetreetxn:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy "dcas-cfg"
+    And chaincode "document", version "v1", package ID "document:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" and collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
 
-    And "system" chaincode "configscc" is instantiated from path "in-process" on the "yourchannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "yourchannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
-    And "system" chaincode "document" is instantiated from path "in-process" on the "yourchannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
+    Then chaincode "configscc", version "v1", package ID "configscc:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "yourchannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy ""
+    And chaincode "sidetreetxn", version "v1", package ID "sidetreetxn:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "yourchannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy "dcas-cfg"
+    And chaincode "document", version "v1", package ID "document:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "yourchannel" channel with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" and collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed

--- a/test/bddtests/features/discovery-handler.feature
+++ b/test/bddtests/features/discovery-handler.feature
@@ -13,7 +13,7 @@ Feature:
     # Give the peers some time to gossip their new channel membership
     And we wait 20 seconds
 
-    And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
+    Then chaincode "configscc", version "v1", package ID "configscc:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy ""
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed

--- a/test/bddtests/features/file-handler.feature
+++ b/test/bddtests/features/file-handler.feature
@@ -21,12 +21,12 @@ Feature:
     # Give the peers some time to gossip their new channel membership
     And we wait 20 seconds
 
-    And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
-    And "system" chaincode "document" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
+    Then chaincode "configscc", version "v1", package ID "configscc:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy ""
+    And chaincode "sidetreetxn", version "v1", package ID "sidetreetxn:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy "dcas-cfg"
+    And chaincode "document", version "v1", package ID "document:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" and collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
 
     Given DCAS collection config "consortium-files-cfg" is defined for collection "consortium" as policy="OR('Org1MSP.member','Org2MSP.member')", requiredPeerCount=1, maxPeerCount=2, and timeToLive=
-    And "system" chaincode "file" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "consortium-files-cfg"
+    And chaincode "file", version "v1", package ID "file:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" and collection policy "consortium-files-cfg"
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed

--- a/test/bddtests/features/sidetreetxn.feature
+++ b/test/bddtests/features/sidetreetxn.feature
@@ -23,9 +23,9 @@ Feature:
     # Give the peers some time to gossip their new channel membership
     And we wait 20 seconds
 
-    And "system" chaincode "configscc" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy ""
-    And "system" chaincode "sidetreetxn" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" with collection policy "dcas-cfg"
-    And "system" chaincode "document" is instantiated from path "in-process" on the "mychannel" channel with args "" with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" with collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
+    Then chaincode "configscc", version "v1", package ID "configscc:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy ""
+    And chaincode "sidetreetxn", version "v1", package ID "sidetreetxn:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "AND('Org1MSP.member','Org2MSP.member')" and collection policy "dcas-cfg"
+    And chaincode "document", version "v1", package ID "document:v1", sequence 1 is approved and committed by orgs "peerorg1,peerorg2" on the "mychannel" channel with endorsement policy "OR('Org1MSP.member','Org2MSP.member')" and collection policy "diddoc-cfg,fileidx-cfg,meta-data-cfg"
 
     And fabric-cli network is initialized
     And fabric-cli plugin "../../.build/ledgerconfig" is installed

--- a/test/bddtests/features/step_definitions/common_steps.js
+++ b/test/bddtests/features/step_definitions/common_steps.js
@@ -133,4 +133,39 @@ defineSupportCode(function ({And, But, Given, Then, When}) {
     And(/^the authorization bearer token for "([^"]*)" requests to path "([^"]*)" is set to "([^"]*)"$/, function (arg1, arg2, callback) {
         callback.pending();
     });
+
+    // Lifecycle steps
+    Given(/^chaincode "([^"]*)" is installed from path "([^"]*)" to all peers$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    When(/^chaincode "([^"]*)", version "([^"]*)", package ID "([^"]*)", sequence (\d+) is approved by orgs "([^"]*)" on the "([^"]*)" channel with endorsement policy "([^"]*)" and collection policy "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, callback) {
+        callback.pending();
+    });
+    When(/^chaincode "([^"]*)", version "([^"]*)", package ID "([^"]*)", sequence (\d+) is approved by orgs "([^"]*)" on the "([^"]*)" channel with endorsement policy "([^"]*)" and collection policy "([^"]*)" then the error response should contain "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, callback) {
+        callback.pending();
+    });
+    When(/^chaincode "([^"]*)", version "([^"]*)", sequence (\d+) is committed by orgs "([^"]*)" on the "([^"]*)" channel with endorsement policy "([^"]*)" and collection policy "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, arg6, callback) {
+        callback.pending();
+    });
+    When(/^chaincode "([^"]*)", version "([^"]*)", package ID "([^"]*)", sequence (\d+) is checked for readiness by orgs "([^"]*)" on the "([^"]*)" channel with endorsement policy "([^"]*)" and collection policy "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, arg6, arg7, callback) {
+        callback.pending();
+    });
+    When(/^peer "([^"]*)" is queried for installed chaincodes$/, function (arg1, callback) {
+        callback.pending();
+    });
+    When(/^committed chaincode "([^"]*)" is queried by orgs "([^"]*)" on the "([^"]*)" channel$/, function (arg1, arg2, arg3, callback) {
+        callback.pending();
+    });
+    When(/^all committed chaincodes are queried by orgs "([^"]*)" on the "([^"]*)" channel$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    When(/^peer "([^"]*)" is queried for approved chaincode "([^"]*)" and sequence (\d+) on the "([^"]*)" channel$/, function (arg1, arg2, arg4, arg4, callback) {
+        callback.pending();
+    });
+    When(/^peer "([^"]*)" is queried for installed chaincode package "([^"]*)"$/, function (arg1, arg2, callback) {
+        callback.pending();
+    });
+    When(/^chaincode "([^"]*)", version "([^"]*)", package ID "([^"]*)", sequence (\d+) is approved and committed by orgs "([^"]*)" on the "([^"]*)" channel with endorsement policy "([^"]*)" and collection policy "([^"]*)"$/, function (arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, callback) {
+        callback.pending();
+    });
 });

--- a/test/bddtests/fixtures/fabric/config/configtx.yaml
+++ b/test/bddtests/fixtures/fabric/config/configtx.yaml
@@ -155,34 +155,38 @@ Organizations:
 #
 ################################################################################
 Capabilities:
-    # Global capabilities apply to both the orderers and the peers and must be
-    # supported by both.  Set the value of the capability to true to require it.
+    # Channel capabilities apply to both the orderers and the peers and must be
+    # supported by both.
+    # Set the value of the capability to true to require it.
     Channel: &ChannelCapabilities
-        # V1.1 for Global is a catchall flag for behavior which has been
-        # determined to be desired for all orderers and peers running v1.0.x,
-        # but the modification of which would cause imcompatibilities.  Users
-        # should leave this flag set to true.
-        V1_1: true
+        # V2.0 for Channel is a catchall flag for behavior which has been
+        # determined to be desired for all orderers and peers running at the v2.0.0
+        # level, but which would be incompatible with orderers and peers from
+        # prior releases.
+        # Prior to enabling V2.0 channel capabilities, ensure that all
+        # orderers and peers on a channel are at v2.0.0 or later.
+        V2_0: true
 
     # Orderer capabilities apply only to the orderers, and may be safely
-    # manipulated without concern for upgrading peers.  Set the value of the
-    # capability to true to require it.
+    # used with prior release peers.
+    # Set the value of the capability to true to require it.
     Orderer: &OrdererCapabilities
-        # V1.1 for Order is a catchall flag for behavior which has been
-        # determined to be desired for all orderers running v1.0.x, but the
-        # modification of which  would cause imcompatibilities.  Users should
-        # leave this flag set to true.
-        V1_1: true
+        # V1.1 for Orderer is a catchall flag for behavior which has been
+        # determined to be desired for all orderers running at the v1.1.x
+        # level, but which would be incompatible with orderers from prior releases.
+        # Prior to enabling V2.0 orderer capabilities, ensure that all
+        # orderers on a channel are at v2.0.0 or later.
+        V2_0: true
 
     # Application capabilities apply only to the peer network, and may be safely
-    # manipulated without concern for upgrading orderers.  Set the value of the
-    # capability to true to require it.
+    # used with prior release orderers.
+    # Set the value of the capability to true to require it.
     Application: &ApplicationCapabilities
-        # V1.1 for Application is a catchall flag for behavior which has been
-        # determined to be desired for all peers running v1.0.x, but the
-        # modification of which would cause incompatibilities.  Users should
-        # leave this flag set to true.
-        V1_2: true
+        # V2.0 for Application enables the new non-backwards compatible
+        # features and fixes of fabric v2.0.
+        # Prior to enabling V2.0 orderer capabilities, ensure that all
+        # orderers on a channel are at v2.0.0 or later.
+        V2_0: true
 
 
 ################################################################################
@@ -401,8 +405,8 @@ Application: &ApplicationDefaults
     #   /Channel/Application/<PolicyName>
     Policies:
         LifecycleEndorsement:
-            Type: ImplicitMeta
-            Rule: "MAJORITY Endorsement"
+            Type: Signature
+            Rule: "OutOf(2,'Org1MSP.member','Org2MSP.member')"
         Endorsement:
             Type: ImplicitMeta
             Rule: "MAJORITY Endorsement"

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
-	github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200731175120-ef25ded2adde
+	github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200805155644-85f5bfcdb2fd
 	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200731163924-244e4e845359
 )
 

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -309,8 +309,8 @@ github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6 h1:GlzMPygeehW/W8tq2vBiN6DLsTFY5xtvQysu1aqqGoQ=
 github.com/trustbloc/edge-core v0.1.4-0.20200709143857-e104bb29f6c6/go.mod h1:SZg7nAIc9FONS+G7MwEyGkCWCJR3R02bePwTpWxqH5w=
-github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200731175120-ef25ded2adde h1:ny3QL6C47sccv8pIE4/ji0P2y3Aqn5sJPwfd2Q42fB0=
-github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200731175120-ef25ded2adde/go.mod h1:n6tREzyrig+mbobAlqSb+AXoGPm+7l7fjVHoroxmEA4=
+github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200805155644-85f5bfcdb2fd h1:5xIpu4CtnvjY7KvxoRtOMauknEjPa4bBraJizkwkjXk=
+github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200805155644-85f5bfcdb2fd/go.mod h1:n6tREzyrig+mbobAlqSb+AXoGPm+7l7fjVHoroxmEA4=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/trustbloc/sidetree-core-go v0.1.4-0.20200731163924-244e4e845359 h1:hxyICwcOvBlgSRmpv3zykySMBrH1piHZ2udNqPZlcvg=


### PR DESCRIPTION
The channel capabilities were set to v2_0 and the BDD tests were updated to use chaincode lifecycle.

closes #381

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>