### PR TITLE
chore: update sidetree-core

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -507,8 +507,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200804135952-4b9196b6678d
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200804135952-4b9196b6678d/go.mod h1:nfy4kMG38xN9cnfnNsITPdA0DhKUIldnPBJhmtJKbaU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c h1:5S3EhEk+7+Svl+b1AaA11KDYEArMYpFQLyBl9WWMSo0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7 h1:y3tTjg/8Kp2IkwnIsGYeMQeQyahYMNKpWvCYaNY40ek=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/stretchr/testify v1.5.1
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7
 )
 
 replace github.com/hyperledger/fabric => github.com/trustbloc/fabric-mod v0.1.4-0.20200731181404-3659bd5007fe

--- a/go.sum
+++ b/go.sum
@@ -514,8 +514,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200804135952-4b9196b6678d
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200804135952-4b9196b6678d/go.mod h1:nfy4kMG38xN9cnfnNsITPdA0DhKUIldnPBJhmtJKbaU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c h1:5S3EhEk+7+Svl+b1AaA11KDYEArMYpFQLyBl9WWMSo0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7 h1:y3tTjg/8Kp2IkwnIsGYeMQeQyahYMNKpWvCYaNY40ek=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/test/bddtests/filehandler_steps.go
+++ b/test/bddtests/filehandler_steps.go
@@ -11,7 +11,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -30,24 +29,15 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
 )
 
-const publicKeyTemplate = `[
-	{
-  		"id": "%s",
-  		"type": "JwsVerificationKey2020",
-		"purpose": ["ops"],
-  		"jwk": %s
-	}
-  ]`
-
 // FileHandlerSteps
 type FileHandlerSteps struct {
 	httpSteps
 
-	bddContext        *bddtests.BDDContext
-	recoveryKey   *ecdsa.PrivateKey
-	updateKey   *ecdsa.PrivateKey
-	updateKeySigner   helper.Signer
-	updatePublicKey   *jws.JWK
+	bddContext      *bddtests.BDDContext
+	recoveryKey     *ecdsa.PrivateKey
+	updateKey       *ecdsa.PrivateKey
+	updateKeySigner helper.Signer
+	updatePublicKey *jws.JWK
 }
 
 // NewFileHandlerSteps
@@ -261,24 +251,10 @@ func (d *FileHandlerSteps) getOpaqueDocument(content string) ([]byte, error) {
 		d.updateKeySigner = ecsigner.New(privateKey, "ES256", updateKeyID)
 	}
 
-	publicKeyBytes, err := json.Marshal(d.updatePublicKey)
-	if err != nil {
-		return nil, err
-	}
-
-	publicKeysStr := fmt.Sprintf(publicKeyTemplate, updateKeyID, string(publicKeyBytes))
-
-	var publicKeys []map[string]interface{}
-	err = json.Unmarshal([]byte(publicKeysStr), &publicKeys)
-	if err != nil {
-		return nil, err
-	}
-
 	doc, err := document.FromBytes([]byte(content))
 	if err != nil {
 		return nil, err
 	}
-	doc["publicKey"] = publicKeys
 
 	return doc.Bytes()
 }

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200805155644-85f5bfcdb2fd
-	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c
+	github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -313,8 +313,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200805155644-85f5bfcdb2f
 github.com/trustbloc/fabric-peer-test-common v0.1.4-0.20200805155644-85f5bfcdb2fd/go.mod h1:n6tREzyrig+mbobAlqSb+AXoGPm+7l7fjVHoroxmEA4=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca h1:XFu6UF1+2kOH+GNVwLDlqcr38HVngfz+/AE/ZaiLJPU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4-0.20200626180529-18936b36feca/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c h1:5S3EhEk+7+Svl+b1AaA11KDYEArMYpFQLyBl9WWMSo0=
-github.com/trustbloc/sidetree-core-go v0.1.4-0.20200811071605-70117e909a5c/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7 h1:y3tTjg/8Kp2IkwnIsGYeMQeQyahYMNKpWvCYaNY40ek=
+github.com/trustbloc/sidetree-core-go v0.1.4-0.20200814162815-6501ed010bf7/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=


### PR DESCRIPTION
Update to latest sidetree-core. Changes included:
- removed "ops" purpose
- if applying patch fails we should continue to the next patch
- removed validation of optional service parameters
- fixed 'resolution loops indefinitely when operation's commitment equals next operation commitment'

Also, there is no longer need to insert update key in the doc for filehandler (removed functionality)

Closes #392

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>