### PR TITLE
fix: Protocol client Current() uses current block number

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -510,8 +510,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f/go.mod h1:rf5xsfz1b0jcSCYwMYPXKFoVfwQto2darddFaWHabv8=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4 h1:XaeZ4bPfGRsiJE2HbU9hEKzAtyYfbOFjVdKIVIKdmyw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4 h1:rnHipgA4mqR7J/cNgen4ZjaghCV0UaEKwVo3j38NDRY=
-github.com/trustbloc/sidetree-core-go v0.1.4/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287 h1:IVezingwhCb8D0UtzDRxWbSVr3H1rAvm29VNY+Lcv3Y=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/edge-core v0.1.4
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.4
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287
 	go.uber.org/zap v1.14.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f/go.mod h1:rf5xsfz1b0jcSCYwMYPXKFoVfwQto2darddFaWHabv8=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4 h1:XaeZ4bPfGRsiJE2HbU9hEKzAtyYfbOFjVdKIVIKdmyw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4 h1:rnHipgA4mqR7J/cNgen4ZjaghCV0UaEKwVo3j38NDRY=
-github.com/trustbloc/sidetree-core-go v0.1.4/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287 h1:IVezingwhCb8D0UtzDRxWbSVr3H1rAvm29VNY+Lcv3Y=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-
+	extmocks "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 	protocolApi "github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 	"github.com/trustbloc/sidetree-core-go/pkg/batch/opqueue"
 
@@ -34,6 +34,7 @@ func TestNew(t *testing.T) {
 	txnProvider := &mocks.TxnServiceProvider{}
 	dcasProvider := &mocks.DCASClientProvider{}
 	opQueueProvider := &mocks.OperationQueueProvider{}
+	ledgerProvider := &extmocks.LedgerProvider{}
 	protocolVersions := map[string]protocolApi.Protocol{}
 
 	errExpected := errors.New("injected op queue error")
@@ -44,13 +45,20 @@ func TestNew(t *testing.T) {
 		Collection:    coll,
 	}
 
-	sctx, err := New(channelID, namespace, dcasCfg, protocolVersions, txnProvider, dcasProvider, opQueueProvider)
+	p := &Providers{
+		TxnProvider:            txnProvider,
+		DCASProvider:           dcasProvider,
+		OperationQueueProvider: opQueueProvider,
+		LedgerProvider:         ledgerProvider,
+	}
+
+	sctx, err := New(channelID, namespace, dcasCfg, protocolVersions, p)
 	require.EqualError(t, err, errExpected.Error())
 	require.Nil(t, sctx)
 
 	opQueueProvider.CreateReturns(&opqueue.MemQueue{}, nil)
 
-	sctx, err = New(channelID, namespace, dcasCfg, protocolVersions, txnProvider, dcasProvider, opQueueProvider)
+	sctx, err = New(channelID, namespace, dcasCfg, protocolVersions, p)
 	require.NoError(t, err)
 	require.NotNil(t, sctx)
 

--- a/pkg/peer/mocks/protocolclient.gen.go
+++ b/pkg/peer/mocks/protocolclient.gen.go
@@ -8,20 +8,21 @@ import (
 )
 
 type ProtocolClient struct {
-	CurrentStub        func() protocol.Protocol
+	CurrentStub        func() (protocol.Protocol, error)
 	currentMutex       sync.RWMutex
-	currentArgsForCall []struct {
-	}
-	currentReturns struct {
+	currentArgsForCall []struct{}
+	currentReturns     struct {
 		result1 protocol.Protocol
+		result2 error
 	}
 	currentReturnsOnCall map[int]struct {
 		result1 protocol.Protocol
+		result2 error
 	}
-	GetStub        func(uint64) (protocol.Protocol, error)
+	GetStub        func(transactionTime uint64) (protocol.Protocol, error)
 	getMutex       sync.RWMutex
 	getArgsForCall []struct {
-		arg1 uint64
+		transactionTime uint64
 	}
 	getReturns struct {
 		result1 protocol.Protocol
@@ -35,21 +36,19 @@ type ProtocolClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ProtocolClient) Current() protocol.Protocol {
+func (fake *ProtocolClient) Current() (protocol.Protocol, error) {
 	fake.currentMutex.Lock()
 	ret, specificReturn := fake.currentReturnsOnCall[len(fake.currentArgsForCall)]
-	fake.currentArgsForCall = append(fake.currentArgsForCall, struct {
-	}{})
+	fake.currentArgsForCall = append(fake.currentArgsForCall, struct{}{})
 	fake.recordInvocation("Current", []interface{}{})
 	fake.currentMutex.Unlock()
 	if fake.CurrentStub != nil {
 		return fake.CurrentStub()
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.currentReturns
-	return fakeReturns.result1
+	return fake.currentReturns.result1, fake.currentReturns.result2
 }
 
 func (fake *ProtocolClient) CurrentCallCount() int {
@@ -58,51 +57,43 @@ func (fake *ProtocolClient) CurrentCallCount() int {
 	return len(fake.currentArgsForCall)
 }
 
-func (fake *ProtocolClient) CurrentCalls(stub func() protocol.Protocol) {
-	fake.currentMutex.Lock()
-	defer fake.currentMutex.Unlock()
-	fake.CurrentStub = stub
-}
-
-func (fake *ProtocolClient) CurrentReturns(result1 protocol.Protocol) {
-	fake.currentMutex.Lock()
-	defer fake.currentMutex.Unlock()
+func (fake *ProtocolClient) CurrentReturns(result1 protocol.Protocol, result2 error) {
 	fake.CurrentStub = nil
 	fake.currentReturns = struct {
 		result1 protocol.Protocol
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *ProtocolClient) CurrentReturnsOnCall(i int, result1 protocol.Protocol) {
-	fake.currentMutex.Lock()
-	defer fake.currentMutex.Unlock()
+func (fake *ProtocolClient) CurrentReturnsOnCall(i int, result1 protocol.Protocol, result2 error) {
 	fake.CurrentStub = nil
 	if fake.currentReturnsOnCall == nil {
 		fake.currentReturnsOnCall = make(map[int]struct {
 			result1 protocol.Protocol
+			result2 error
 		})
 	}
 	fake.currentReturnsOnCall[i] = struct {
 		result1 protocol.Protocol
-	}{result1}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *ProtocolClient) Get(arg1 uint64) (protocol.Protocol, error) {
+func (fake *ProtocolClient) Get(transactionTime uint64) (protocol.Protocol, error) {
 	fake.getMutex.Lock()
 	ret, specificReturn := fake.getReturnsOnCall[len(fake.getArgsForCall)]
 	fake.getArgsForCall = append(fake.getArgsForCall, struct {
-		arg1 uint64
-	}{arg1})
-	fake.recordInvocation("Get", []interface{}{arg1})
+		transactionTime uint64
+	}{transactionTime})
+	fake.recordInvocation("Get", []interface{}{transactionTime})
 	fake.getMutex.Unlock()
 	if fake.GetStub != nil {
-		return fake.GetStub(arg1)
+		return fake.GetStub(transactionTime)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.getReturns.result1, fake.getReturns.result2
 }
 
 func (fake *ProtocolClient) GetCallCount() int {
@@ -111,22 +102,13 @@ func (fake *ProtocolClient) GetCallCount() int {
 	return len(fake.getArgsForCall)
 }
 
-func (fake *ProtocolClient) GetCalls(stub func(uint64) (protocol.Protocol, error)) {
-	fake.getMutex.Lock()
-	defer fake.getMutex.Unlock()
-	fake.GetStub = stub
-}
-
 func (fake *ProtocolClient) GetArgsForCall(i int) uint64 {
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
-	argsForCall := fake.getArgsForCall[i]
-	return argsForCall.arg1
+	return fake.getArgsForCall[i].transactionTime
 }
 
 func (fake *ProtocolClient) GetReturns(result1 protocol.Protocol, result2 error) {
-	fake.getMutex.Lock()
-	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	fake.getReturns = struct {
 		result1 protocol.Protocol
@@ -135,8 +117,6 @@ func (fake *ProtocolClient) GetReturns(result1 protocol.Protocol, result2 error)
 }
 
 func (fake *ProtocolClient) GetReturnsOnCall(i int, result1 protocol.Protocol, result2 error) {
-	fake.getMutex.Lock()
-	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	if fake.getReturnsOnCall == nil {
 		fake.getReturnsOnCall = make(map[int]struct {

--- a/pkg/peer/sidetreesvc/channelctrl_test.go
+++ b/pkg/peer/sidetreesvc/channelctrl_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/stretchr/testify/require"
 	ledgerconfig "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
 	cfgservice "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/service"
@@ -21,6 +22,7 @@ import (
 
 	"github.com/trustbloc/sidetree-fabric/pkg/config"
 	cfgmocks "github.com/trustbloc/sidetree-fabric/pkg/config/mocks"
+	sidetreectx "github.com/trustbloc/sidetree-fabric/pkg/context"
 	"github.com/trustbloc/sidetree-fabric/pkg/mocks"
 	"github.com/trustbloc/sidetree-fabric/pkg/observer"
 	mocks2 "github.com/trustbloc/sidetree-fabric/pkg/observer/mocks"
@@ -149,10 +151,21 @@ func TestChannelController_Update(t *testing.T) {
 
 	discoveryProvider := &peermocks.DiscoveryProvider{}
 
+	ledgerProvider := &extmocks.LedgerProvider{}
+	l := &extmocks.Ledger{
+		BlockchainInfo: &cb.BlockchainInfo{
+			Height: 1000,
+		},
+	}
+	ledgerProvider.GetLedgerReturns(l)
+
 	providers := &providers{
 		ContextProviders: &ContextProviders{
-			DCASProvider:           dcasProvider,
-			OperationQueueProvider: opQueueProvider,
+			Providers: &sidetreectx.Providers{
+				DCASProvider:           dcasProvider,
+				OperationQueueProvider: opQueueProvider,
+				LedgerProvider:         ledgerProvider,
+			},
 		},
 		PeerConfig:        peerConfig,
 		ConfigProvider:    configProvider,
@@ -345,10 +358,21 @@ func TestChannelController_LoadDCASHandlers(t *testing.T) {
 
 	discoveryProvider := &peermocks.DiscoveryProvider{}
 
+	ledgerProvider := &extmocks.LedgerProvider{}
+	l := &extmocks.Ledger{
+		BlockchainInfo: &cb.BlockchainInfo{
+			Height: 1000,
+		},
+	}
+	ledgerProvider.GetLedgerReturns(l)
+
 	providers := &providers{
 		ContextProviders: &ContextProviders{
-			DCASProvider:           dcasProvider,
-			OperationQueueProvider: opQueueProvider,
+			Providers: &sidetreectx.Providers{
+				DCASProvider:           dcasProvider,
+				OperationQueueProvider: opQueueProvider,
+				LedgerProvider:         ledgerProvider,
+			},
 		},
 		PeerConfig:        peerConfig,
 		ConfigProvider:    configProvider,
@@ -404,10 +428,21 @@ func TestChannelController_LoadBlockchainHandlers(t *testing.T) {
 
 	discoveryProvider := &peermocks.DiscoveryProvider{}
 
+	ledgerProvider := &extmocks.LedgerProvider{}
+	l := &extmocks.Ledger{
+		BlockchainInfo: &cb.BlockchainInfo{
+			Height: 1000,
+		},
+	}
+	ledgerProvider.GetLedgerReturns(l)
+
 	providers := &providers{
 		ContextProviders: &ContextProviders{
-			OperationQueueProvider: opQueueProvider,
-			BlockchainProvider:     blockchainProvider,
+			Providers: &sidetreectx.Providers{
+				OperationQueueProvider: opQueueProvider,
+				LedgerProvider:         ledgerProvider,
+			},
+			BlockchainProvider: blockchainProvider,
 		},
 		PeerConfig:        peerConfig,
 		ConfigProvider:    configProvider,
@@ -470,11 +505,22 @@ func TestChannelController_LoadDiscoveryHandlers(t *testing.T) {
 	blockchainProvider := &mocks2.BlockchainClientProvider{}
 
 	discoveryProvider := &peermocks.DiscoveryProvider{}
+	ledgerProvider := &extmocks.LedgerProvider{}
+
+	l := &extmocks.Ledger{
+		BlockchainInfo: &cb.BlockchainInfo{
+			Height: 1000,
+		},
+	}
+	ledgerProvider.GetLedgerReturns(l)
 
 	providers := &providers{
 		ContextProviders: &ContextProviders{
-			OperationQueueProvider: opQueueProvider,
-			BlockchainProvider:     blockchainProvider,
+			Providers: &sidetreectx.Providers{
+				OperationQueueProvider: opQueueProvider,
+				LedgerProvider:         ledgerProvider,
+			},
+			BlockchainProvider: blockchainProvider,
 		},
 		PeerConfig:        peerConfig,
 		ConfigProvider:    configProvider,

--- a/pkg/peer/sidetreesvc/context.go
+++ b/pkg/peer/sidetreesvc/context.go
@@ -58,16 +58,14 @@ type blockchainClientProvider interface {
 
 // ContextProviders defines the providers required by the context
 type ContextProviders struct {
-	TxnProvider            txnServiceProvider
-	DCASProvider           dcasClientProvider
-	OperationQueueProvider operationQueueProvider
-	BlockchainProvider     blockchainClientProvider
+	*sidetreectx.Providers
+	BlockchainProvider blockchainClientProvider
 }
 
 func newContext(channelID string, handlerCfg sidetreehandler.Config, dcasCfg config.DCAS, cfg config.SidetreeService, providers *ContextProviders, opStoreProvider common.OperationStoreProvider, tokenProvider tokenProvider) (*context, error) {
 	logger.Debugf("[%s] Creating Sidetree context for [%s]", channelID, handlerCfg.Namespace)
 
-	ctx, err := newSidetreeContext(channelID, handlerCfg.Namespace, cfg, dcasCfg, providers.TxnProvider, providers.DCASProvider, providers.OperationQueueProvider)
+	ctx, err := newSidetreeContext(channelID, handlerCfg.Namespace, cfg, dcasCfg, providers.Providers)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +97,7 @@ func newContext(channelID string, handlerCfg sidetreehandler.Config, dcasCfg con
 	}, nil
 }
 
-func newSidetreeContext(channelID, namespace string, cfg config.SidetreeService, dcasCfg config.DCAS, txnProvider txnServiceProvider, dcasProvider dcasClientProvider, opQueueProvider operationQueueProvider) (*sidetreectx.SidetreeContext, error) {
+func newSidetreeContext(channelID, namespace string, cfg config.SidetreeService, dcasCfg config.DCAS, providers *sidetreectx.Providers) (*sidetreectx.SidetreeContext, error) {
 	protocolVersions, err := cfg.LoadProtocols(namespace)
 	if err != nil {
 		return nil, err
@@ -109,5 +107,5 @@ func newSidetreeContext(channelID, namespace string, cfg config.SidetreeService,
 		return nil, errors.Errorf("no protocols defined for [%s]", namespace)
 	}
 
-	return sidetreectx.New(channelID, namespace, dcasCfg, protocolVersions, txnProvider, dcasProvider, opQueueProvider)
+	return sidetreectx.New(channelID, namespace, dcasCfg, protocolVersions, providers)
 }

--- a/pkg/peer/sidetreesvc/context_test.go
+++ b/pkg/peer/sidetreesvc/context_test.go
@@ -12,11 +12,12 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-
+	extmocks "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
 	protocolApi "github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 
 	"github.com/trustbloc/sidetree-fabric/pkg/config"
 	cfgmocks "github.com/trustbloc/sidetree-fabric/pkg/config/mocks"
+	sidetreectx "github.com/trustbloc/sidetree-fabric/pkg/context"
 	"github.com/trustbloc/sidetree-fabric/pkg/mocks"
 	peermocks "github.com/trustbloc/sidetree-fabric/pkg/peer/mocks"
 	"github.com/trustbloc/sidetree-fabric/pkg/rest/sidetreehandler"
@@ -39,9 +40,12 @@ func TestContext(t *testing.T) {
 	restCfg := &peermocks.RestConfig{}
 
 	ctxProviders := &ContextProviders{
-		TxnProvider:            &peermocks.TxnServiceProvider{},
-		DCASProvider:           &peermocks.DCASClientProvider{},
-		OperationQueueProvider: &mocks.OperationQueueProvider{},
+		Providers: &sidetreectx.Providers{
+			TxnProvider:            &peermocks.TxnServiceProvider{},
+			DCASProvider:           &peermocks.DCASClientProvider{},
+			OperationQueueProvider: &mocks.OperationQueueProvider{},
+			LedgerProvider:         &extmocks.LedgerProvider{},
+		},
 	}
 
 	t.Run("Success", func(t *testing.T) {

--- a/pkg/peer/sidetreesvc/provider.go
+++ b/pkg/peer/sidetreesvc/provider.go
@@ -10,10 +10,7 @@ import (
 	"sync"
 
 	"github.com/hyperledger/fabric/common/flogging"
-	dcas "github.com/trustbloc/fabric-peer-ext/pkg/collections/offledger/dcas/client"
 	ledgerconfig "github.com/trustbloc/fabric-peer-ext/pkg/config/ledgerconfig/config"
-	txnapi "github.com/trustbloc/fabric-peer-ext/pkg/txn/api"
-	"github.com/trustbloc/sidetree-core-go/pkg/batch/cutter"
 	"github.com/trustbloc/sidetree-core-go/pkg/restapi/common"
 
 	"github.com/trustbloc/sidetree-fabric/pkg/config"
@@ -24,10 +21,6 @@ import (
 
 var logger = flogging.MustGetLogger("sidetree_peer")
 
-type txnServiceProvider interface {
-	ForChannel(channelID string) (txnapi.Service, error)
-}
-
 type configServiceProvider interface {
 	ForChannel(channelID string) ledgerconfig.Service
 }
@@ -36,10 +29,6 @@ type peerConfig interface {
 	PeerID() string
 	PeerAddress() string
 	MSPID() string
-}
-
-type dcasClientProvider interface {
-	ForChannel(channelID string) (dcas.DCAS, error)
 }
 
 type restConfig interface {
@@ -52,10 +41,6 @@ type restConfig interface {
 
 type sidetreeConfigProvider interface {
 	ForChannel(channelID string) config.SidetreeService
-}
-
-type operationQueueProvider interface {
-	Create(channelID string, namespace string) (cutter.OperationQueue, error)
 }
 
 type discoveryProvider interface {

--- a/pkg/peer/sidetreesvc/provider_test.go
+++ b/pkg/peer/sidetreesvc/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	cb "github.com/hyperledger/fabric-protos-go/common"
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/fabric-peer-ext/pkg/gossip/blockpublisher"
 	extmocks "github.com/trustbloc/fabric-peer-ext/pkg/mocks"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/trustbloc/sidetree-fabric/pkg/config"
 	cfgmocks "github.com/trustbloc/sidetree-fabric/pkg/config/mocks"
+	sidetreectx "github.com/trustbloc/sidetree-fabric/pkg/context"
 	"github.com/trustbloc/sidetree-fabric/pkg/mocks"
 	"github.com/trustbloc/sidetree-fabric/pkg/observer"
 	peermocks "github.com/trustbloc/sidetree-fabric/pkg/peer/mocks"
@@ -96,10 +98,21 @@ func TestProvider(t *testing.T) {
 
 	discoveryProvider := &peermocks.DiscoveryProvider{}
 
+	ledgerProvider := &extmocks.LedgerProvider{}
+	l := &extmocks.Ledger{
+		BlockchainInfo: &cb.BlockchainInfo{
+			Height: 1000,
+		},
+	}
+	ledgerProvider.GetLedgerReturns(l)
+
 	providers := &providers{
 		ContextProviders: &ContextProviders{
-			OperationQueueProvider: opQueueProvider,
-			DCASProvider:           dcasProvider,
+			Providers: &sidetreectx.Providers{
+				OperationQueueProvider: opQueueProvider,
+				DCASProvider:           dcasProvider,
+				LedgerProvider:         ledgerProvider,
+			},
 		},
 		PeerConfig:        peerConfig,
 		RESTConfig:        restConfig,

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/trustbloc/fabric-peer-test-common v0.1.4
-	github.com/trustbloc/sidetree-core-go v0.1.4
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.4

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -315,8 +315,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.4 h1:oD0MvoN2EQgGcWKKE7qdIgfRS
 github.com/trustbloc/fabric-peer-test-common v0.1.4/go.mod h1:7Cfp0qdzZYjLGoge4HNEO5yuosz0XaT/4F/2688x8Ug=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4 h1:XaeZ4bPfGRsiJE2HbU9hEKzAtyYfbOFjVdKIVIKdmyw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.4 h1:rnHipgA4mqR7J/cNgen4ZjaghCV0UaEKwVo3j38NDRY=
-github.com/trustbloc/sidetree-core-go v0.1.4/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287 h1:IVezingwhCb8D0UtzDRxWbSVr3H1rAvm29VNY+Lcv3Y=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200902180636-c8d655777287/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=


### PR DESCRIPTION
The implementation of the protocol client function, Current(), is now based on the current blockchain time (block number).

closes #412

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>