### PR TITLE
chore: Update to latest sidetree-core-go

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -510,8 +510,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f/go.mod h1:rf5xsfz1b0jcSCYwMYPXKFoVfwQto2darddFaWHabv8=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4 h1:XaeZ4bPfGRsiJE2HbU9hEKzAtyYfbOFjVdKIVIKdmyw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094 h1:ezhLXoNTxJ0VfuaoKkg3ROGQjTGJoJBdoh+uNyMZczQ=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d h1:QxyZzB6D4eKjiWLJRlV4R2eewMxmcWM6IU3XbJX93v4=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/edge-core v0.1.4
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d
 	go.uber.org/zap v1.14.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -517,8 +517,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20200902124622-3c735642587f/go.mod h1:rf5xsfz1b0jcSCYwMYPXKFoVfwQto2darddFaWHabv8=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4 h1:XaeZ4bPfGRsiJE2HbU9hEKzAtyYfbOFjVdKIVIKdmyw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094 h1:ezhLXoNTxJ0VfuaoKkg3ROGQjTGJoJBdoh+uNyMZczQ=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d h1:QxyZzB6D4eKjiWLJRlV4R2eewMxmcWM6IU3XbJX93v4=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/context/blockchain/client.go
+++ b/pkg/context/blockchain/client.go
@@ -44,15 +44,16 @@ func New(channelID, chaincodeName, namespace string, txnProvider txnServiceProvi
 }
 
 // WriteAnchor writes anchor string to blockchain
-func (c *Client) WriteAnchor(anchor string) error {
+func (c *Client) WriteAnchor(anchor string, protocolGenesisTime uint64) error {
 	txnService, err := c.txnProvider.ForChannel(c.channelID)
 	if err != nil {
 		return err
 	}
 
 	txnInfo := common.TxnInfo{
-		AnchorString: anchor,
-		Namespace:    c.namespace,
+		AnchorString:        anchor,
+		Namespace:           c.namespace,
+		ProtocolGenesisTime: protocolGenesisTime,
 	}
 
 	txnInfoBytes, err := json.Marshal(txnInfo)

--- a/pkg/context/blockchain/client_test.go
+++ b/pkg/context/blockchain/client_test.go
@@ -35,7 +35,7 @@ func TestGetClientError(t *testing.T) {
 	c := New(chID, ccName, namespace, txnProvider)
 	require.NotNil(t, c)
 
-	err := c.WriteAnchor("anchor")
+	err := c.WriteAnchor("anchor", 100)
 	require.EqualError(t, err, testErr.Error())
 }
 
@@ -46,7 +46,7 @@ func TestWriteAnchor(t *testing.T) {
 
 	c := New(chID, ccName, namespace, txnProvider)
 
-	err := c.WriteAnchor("anchor")
+	err := c.WriteAnchor("anchor", 100)
 	require.Nil(t, err)
 }
 
@@ -61,7 +61,7 @@ func TestWriteAnchorError(t *testing.T) {
 	txnProvider.ForChannelReturns(txnService, nil)
 	bc := New(chID, ccName, namespace, txnProvider)
 
-	err := bc.WriteAnchor("anchor")
+	err := bc.WriteAnchor("anchor", 100)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), testErr.Error())
 }

--- a/pkg/context/store/client.go
+++ b/pkg/context/store/client.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	queryByUniqueSuffixTemplate = `{"selector":{"unique_suffix":"%s"},"use_index":["_design/indexUniqueSuffixDoc","indexUniqueSuffix"],"fields":["unique_suffix","type","delta","signed_data","suffix_data","transaction_time","transaction_number","operation_index"]}`
+	queryByUniqueSuffixTemplate = `{"selector":{"unique_suffix":"%s"},"use_index":["_design/indexUniqueSuffixDoc","indexUniqueSuffix"],"fields":["unique_suffix","type","delta","signed_data","suffix_data","transaction_time","transaction_number","operation_index","protocol_genesis_time"]}`
 )
 
 var logger = flogging.MustGetLogger("sidetree_context")

--- a/pkg/observer/common/constants.go
+++ b/pkg/observer/common/constants.go
@@ -15,4 +15,6 @@ const (
 type TxnInfo struct {
 	AnchorString string `json:"anchor_string"`
 	Namespace    string `json:"namespace"`
+	// ProtocolGenesisTime is the genesis time of the protocol that was used to create the anchor
+	ProtocolGenesisTime uint64 `json:"protocol_genesis_time"`
 }

--- a/pkg/observer/observer.go
+++ b/pkg/observer/observer.go
@@ -319,10 +319,11 @@ func (m *Observer) writeHandler(metadata *Metadata) blockvisitor.WriteHandler {
 		logger.Debugf("[%s] Handling write to anchor [%s] in block [%d] and TxNum [%d] on attempt #%d", m.channelID, w.Write.Value, w.BlockNum, w.TxNum, metadata.FailedAttempts+1)
 
 		sidetreeTxn := txn.SidetreeTxn{
-			TransactionTime:   w.BlockNum,
-			TransactionNumber: w.TxNum,
-			AnchorString:      txnInfo.AnchorString,
-			Namespace:         txnInfo.Namespace,
+			TransactionTime:     w.BlockNum,
+			TransactionNumber:   w.TxNum,
+			AnchorString:        txnInfo.AnchorString,
+			Namespace:           txnInfo.Namespace,
+			ProtocolGenesisTime: txnInfo.ProtocolGenesisTime,
 		}
 
 		pv, err := m.pcp.ForNamespace(txnInfo.Namespace)

--- a/pkg/peer/mocks/batchwriter.gen.go
+++ b/pkg/peer/mocks/batchwriter.gen.go
@@ -8,10 +8,11 @@ import (
 )
 
 type BatchWriter struct {
-	AddStub        func(operation *batch.OperationInfo) error
+	AddStub        func(operation *batch.OperationInfo, protocolGenesisTime uint64) error
 	addMutex       sync.RWMutex
 	addArgsForCall []struct {
-		operation *batch.OperationInfo
+		operation           *batch.OperationInfo
+		protocolGenesisTime uint64
 	}
 	addReturns struct {
 		result1 error
@@ -35,16 +36,17 @@ type BatchWriter struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *BatchWriter) Add(operation *batch.OperationInfo) error {
+func (fake *BatchWriter) Add(operation *batch.OperationInfo, protocolGenesisTime uint64) error {
 	fake.addMutex.Lock()
 	ret, specificReturn := fake.addReturnsOnCall[len(fake.addArgsForCall)]
 	fake.addArgsForCall = append(fake.addArgsForCall, struct {
-		operation *batch.OperationInfo
-	}{operation})
-	fake.recordInvocation("Add", []interface{}{operation})
+		operation           *batch.OperationInfo
+		protocolGenesisTime uint64
+	}{operation, protocolGenesisTime})
+	fake.recordInvocation("Add", []interface{}{operation, protocolGenesisTime})
 	fake.addMutex.Unlock()
 	if fake.AddStub != nil {
-		return fake.AddStub(operation)
+		return fake.AddStub(operation, protocolGenesisTime)
 	}
 	if specificReturn {
 		return ret.result1
@@ -58,10 +60,10 @@ func (fake *BatchWriter) AddCallCount() int {
 	return len(fake.addArgsForCall)
 }
 
-func (fake *BatchWriter) AddArgsForCall(i int) *batch.OperationInfo {
+func (fake *BatchWriter) AddArgsForCall(i int) (*batch.OperationInfo, uint64) {
 	fake.addMutex.RLock()
 	defer fake.addMutex.RUnlock()
-	return fake.addArgsForCall[i].operation
+	return fake.addArgsForCall[i].operation, fake.addArgsForCall[i].protocolGenesisTime
 }
 
 func (fake *BatchWriter) AddReturns(result1 error) {

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/trustbloc/fabric-peer-test-common v0.1.4
-	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094
+	github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.4

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -315,8 +315,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.4 h1:oD0MvoN2EQgGcWKKE7qdIgfRS
 github.com/trustbloc/fabric-peer-test-common v0.1.4/go.mod h1:7Cfp0qdzZYjLGoge4HNEO5yuosz0XaT/4F/2688x8Ug=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4 h1:XaeZ4bPfGRsiJE2HbU9hEKzAtyYfbOFjVdKIVIKdmyw=
 github.com/trustbloc/fabric-protos-go-ext v0.1.4/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094 h1:ezhLXoNTxJ0VfuaoKkg3ROGQjTGJoJBdoh+uNyMZczQ=
-github.com/trustbloc/sidetree-core-go v0.1.5-0.20200921131621-6f4d6a76b094/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d h1:QxyZzB6D4eKjiWLJRlV4R2eewMxmcWM6IU3XbJX93v4=
+github.com/trustbloc/sidetree-core-go v0.1.5-0.20200922205534-e629dd46dd6d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=


### PR DESCRIPTION
Update to latest sidetree-core-go which persists the protocol genesis time with each operation so that the operation is consistently processed with the same protocol version at each stage, i.e. batch writer, observer, and resolver.

closes #429

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>