### PR TITLE
chore: Change file handler path to be consistent with DID

### DIFF
--- a/pkg/peer/sidetreesvc/channelctrl.go
+++ b/pkg/peer/sidetreesvc/channelctrl.go
@@ -492,7 +492,7 @@ func (c *channelController) loadFileService(cfg filehandler.Config) (*service, e
 		logger.Debugf("[%s] Authorization tokens for file read handler: %s", c.channelID, cfg.Authorization.ReadTokens)
 
 		s.endpoints = append(s.endpoints,
-			newEndpoint("", c.authHandler(cfg.Authorization.ReadTokens, filehandler.NewRetrieveHandler(c.channelID, cfg, docHandler, c.DCASProvider))),
+			newEndpoint("/identifiers", c.authHandler(cfg.Authorization.ReadTokens, filehandler.NewRetrieveHandler(c.channelID, cfg, docHandler, c.DCASProvider))),
 		)
 	}
 
@@ -501,7 +501,7 @@ func (c *channelController) loadFileService(cfg filehandler.Config) (*service, e
 		logger.Debugf("[%s] Authorization tokens for file upload handler: %s", c.channelID, cfg.Authorization.WriteTokens)
 
 		s.endpoints = append(s.endpoints,
-			newEndpoint("", c.authHandler(cfg.Authorization.WriteTokens, filehandler.NewUploadHandler(c.channelID, cfg, c.DCASProvider))),
+			newEndpoint("/operations", c.authHandler(cfg.Authorization.WriteTokens, filehandler.NewUploadHandler(c.channelID, cfg, c.DCASProvider))),
 		)
 	}
 

--- a/pkg/rest/filehandler/resolveindexhandler.go
+++ b/pkg/rest/filehandler/resolveindexhandler.go
@@ -29,7 +29,7 @@ func NewResolveIndexHandler(path string, resolver dochandler.Resolver) *ResolveI
 
 // Path returns the context path
 func (h *ResolveIndex) Path() string {
-	return h.path + "/{id}"
+	return h.path + "/identifiers/{id}"
 }
 
 // Method returns the HTTP method

--- a/pkg/rest/filehandler/resolveindexhandler_test.go
+++ b/pkg/rest/filehandler/resolveindexhandler_test.go
@@ -18,7 +18,7 @@ func TestResolveIndex(t *testing.T) {
 
 	h := NewResolveIndexHandler(path, nil)
 	require.NotNil(t, h)
-	require.Equal(t, "/file/{id}", h.Path())
+	require.Equal(t, "/file/identifiers/{id}", h.Path())
 	require.NotNil(t, h.Handler())
 	require.Equal(t, http.MethodGet, h.Method())
 }

--- a/pkg/rest/filehandler/updateindexhandler.go
+++ b/pkg/rest/filehandler/updateindexhandler.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package filehandler
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
@@ -23,7 +24,7 @@ type UpdateIndex struct {
 // NewUpdateIndexHandler returns a new update index handler
 func NewUpdateIndexHandler(path string, processor resthandler.Processor, pc protocol.Client) *UpdateIndex {
 	return &UpdateIndex{
-		path:          path,
+		path:          fmt.Sprintf("%s/operations", path),
 		UpdateHandler: resthandler.NewUpdateHandler(processor, pc),
 	}
 }

--- a/pkg/rest/filehandler/updateindexhandler_test.go
+++ b/pkg/rest/filehandler/updateindexhandler_test.go
@@ -18,7 +18,7 @@ func TestUpdateIndex(t *testing.T) {
 
 	h := NewUpdateIndexHandler(path, nil, nil)
 	require.NotNil(t, h)
-	require.Equal(t, "/file", h.Path())
+	require.Equal(t, "/file/operations", h.Path())
 	require.NotNil(t, h.Handler())
 	require.Equal(t, http.MethodPost, h.Method())
 }


### PR DESCRIPTION
The file paths for retrieve and update handlers are now prefixed with /identifiers and /operations respectively. Previously there was no prefix and therefore the /version endpoint was being ignored and the /version request was directed to the retrieve handler. This change makes the file endpoint consistent with the DID endpoints.

Also added a BDD test for file version.

closes #433

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>