### PR TITLE
chore: Remove public keys processing from filehandler transformer

### DIFF
--- a/pkg/rest/filehandler/transformer.go
+++ b/pkg/rest/filehandler/transformer.go
@@ -30,31 +30,5 @@ func (v *Transformer) TransformDocument(doc document.Document) (*document.Resolu
 		MethodMetadata: document.MethodMetadata{},
 	}
 
-	processKeys(doc)
-
 	return resolutionResult, nil
-}
-
-// generic documents will most likely only contain operation keys
-// operation keys are not part of external document but resolution result
-func processKeys(internal document.Document) {
-	var pubKeys []document.PublicKey
-
-	for _, pk := range internal.PublicKeys() {
-		externalPK := make(document.PublicKey)
-		externalPK[document.IDProperty] = internal.ID() + "#" + pk.ID()
-		externalPK[document.TypeProperty] = pk.Type()
-		externalPK[document.ControllerProperty] = internal[document.IDProperty]
-		externalPK[document.PublicKeyJwkProperty] = pk.PublicKeyJwk()
-
-		delete(pk, document.PurposesProperty)
-
-		pubKeys = append(pubKeys, externalPK)
-	}
-
-	if len(pubKeys) > 0 {
-		internal[document.PublicKeyProperty] = pubKeys
-	} else {
-		delete(internal, document.PublicKeyProperty)
-	}
 }

--- a/pkg/rest/filehandler/transformer_test.go
+++ b/pkg/rest/filehandler/transformer_test.go
@@ -26,7 +26,7 @@ func TestDocumentTransformer_TransformDocument(t *testing.T) {
 	})
 
 	t.Run("document with no keys", func(t *testing.T) {
-		doc, err := document.FromBytes([]byte(validDocNoKeys))
+		doc, err := document.FromBytes([]byte(validDoc))
 		require.NoError(t, err)
 
 		result, err := v.TransformDocument(doc)
@@ -39,60 +39,11 @@ func TestDocumentTransformer_TransformDocument(t *testing.T) {
 		require.Equal(t, 0, len(didDoc.PublicKeys()))
 	})
 
-	t.Run("document with two general keys", func(t *testing.T) {
-		// most likely this scenario will not be used
-		doc, err := document.FromBytes([]byte(validDocWithKeys))
-		require.NoError(t, err)
-
-		result, err := v.TransformDocument(doc)
-		require.NoError(t, err)
-
-		jsonTransformed, err := json.Marshal(result.Document)
-		require.NoError(t, err)
-		didDoc, err := document.DidDocumentFromBytes(jsonTransformed)
-		require.NoError(t, err)
-		require.Equal(t, 2, len(didDoc.PublicKeys()))
-	})
 }
 
-const validDocNoKeys = `
+const validDoc = `
 {
   "id" : "doc:method:abc",
-  "other": [
-    {
-      "name": "name"
-    }
-  ]
-}`
-
-// TODO: Revisit if keys are needed for generic documents
-const validDocWithKeys = `
-{
-  "id" : "doc:method:abc",
-  "publicKey": [
-    {
-      "id": "auth-key",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["general"],
-      "jwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    },
-    {
-      "id": "general-key",
-      "type": "JwsVerificationKey2020",
-      "purpose": ["general"],
-      "jwk": {
-        "kty": "EC",
-        "crv": "P-256K",
-        "x": "PUymIqdtF_qxaAqPABSw-C-owT1KYYQbsMKFM-L9fJA",
-        "y": "nM84jDHCMOTGTh_ZdHq4dBBdo4Z5PkEOW9jA8z8IsGc"
-      }
-    }
-  ],
   "other": [
     {
       "name": "name"


### PR DESCRIPTION
There is no need for generic document to have public keys in the document. The requirement for update key to be part of the document has been removed couple of months ago. This is leftover code - not used any more.

Closes #455

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>