### PR TITLE
fix: Updated the CouchDB index for document store

### DIFF
--- a/cmd/chaincode/doc/doc.go
+++ b/cmd/chaincode/doc/doc.go
@@ -21,7 +21,7 @@ const (
 	ccVersion = "v1"
 
 	couchDB       = "couchdb"
-	docsCollIndex = `{"index": {"fields": ["unique_suffix"]}, "ddoc": "indexUniqueSuffixDoc", "name": "indexUniqueSuffix", "type": "json"}`
+	docsCollIndex = `{"index": {"fields": ["uniqueSuffix"]}, "ddoc": "indexUniqueSuffixDoc", "name": "indexUniqueSuffix", "type": "json"}`
 )
 
 // DocumentCC is used to setup database, collection and indexes for documents


### PR DESCRIPTION
The field name, unique_suffix, was changed to, uniqueSuffix.

closes #463

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>