### PR TITLE
fix: Return HTTP 400 when max-size not specified in cas URL

### DIFF
--- a/pkg/rest/dcashandler/retrievehandler_test.go
+++ b/pkg/rest/dcashandler/retrievehandler_test.go
@@ -41,7 +41,6 @@ func TestNewRetrieveHandler(t *testing.T) {
 
 	require.Equal(t, "/cas/{hash}", h.Path())
 	require.Equal(t, http.MethodGet, h.Method())
-	require.NotEmpty(t, h.Params()[maxSizeParam])
 }
 
 func TestRetrieve_Handler(t *testing.T) {

--- a/test/bddtests/features/dcas-handler.feature
+++ b/test/bddtests/features/dcas-handler.feature
@@ -49,6 +49,9 @@ Feature:
     When an HTTP POST is sent to "https://localhost:48326/sidetree/0.0.1/cas" with content from file "fixtures/testdata/schemas/geographical-location.schema.json"
     Then the JSON path "hash" of the response is saved to variable "contentHash"
 
+    When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${contentHash}" and the returned status code is 400
+    Then the response equals "content_max_size_not_specified"
+
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/cas/${contentHash}?max-size=1" and the returned status code is 400
     Then the response equals "content_exceeds_maximum_allowed_size"
 


### PR DESCRIPTION
If the URL for cas does not contain the parameter, max-size=n, then HTTP 400 (bad request) is returned.

closes #462

Signed-off-by: Bob Stasyszyn <Bob.Stasyszyn@securekey.com>