### PR TITLE
chore: add method context and enable @base configuration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -47,6 +47,7 @@ type Sidetree struct {
 	Collection         string
 	BatchWriterTimeout time.Duration
 	MethodContext      []string
+	EnableBase         bool
 }
 
 // SidetreeService is a service that loads Sidetree configuration

--- a/pkg/peer/config/service_test.go
+++ b/pkg/peer/config/service_test.go
@@ -43,6 +43,7 @@ const (
 	didSidetreeNamespace             = "did:sidetree"
 	didSidetreeCfgJSON               = `{"batchWriterTimeout":"5s"}`
 	didSidetreeCfgJSONWithMethodCtx  = `{"batchWriterTimeout":"5s","methodContext":["ctx1","ctx2"]}`
+	didSidetreeCfgJSONWithBase       = `{"batchWriterTimeout":"5s","enableBase":true}`
 	didSidetreeProtocol_V0_4_CfgJSON = `{"genesisTime":200000,"multihashAlgorithm":18,"maxOperationSize":2000,"maxOperationCount":10}`
 	didSidetreeProtocol_V0_5_CfgJSON = `{"genesisTime":500000,"multihashAlgorithm":18,"maxOperationSize":10000,"maxOperationCount":100}`
 	sidetreePeerCfgJson              = `{"Observer":{"Period":"5s"}}`
@@ -139,6 +140,7 @@ func TestNewSidetreeProvider(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 5*time.Second, cfg.BatchWriterTimeout)
 		require.Equal(t, 0, len(cfg.MethodContext))
+		require.Equal(t, false, cfg.EnableBase)
 
 		cfgValue = &ledgercfg.Value{
 			TxID:   "tx1",
@@ -153,6 +155,19 @@ func TestNewSidetreeProvider(t *testing.T) {
 		require.Equal(t, 2, len(cfg.MethodContext))
 		require.Equal(t, "ctx1", cfg.MethodContext[0])
 		require.Equal(t, "ctx2", cfg.MethodContext[1])
+
+		cfgValue = &ledgercfg.Value{
+			TxID:   "tx1",
+			Format: "json",
+			Config: didSidetreeCfgJSONWithBase,
+		}
+		configService.GetReturns(cfgValue, nil)
+
+		cfg, err = s.LoadSidetree(didSidetreeNamespace)
+		require.NoError(t, err)
+		require.Equal(t, 5*time.Second, cfg.BatchWriterTimeout)
+		require.Equal(t, 0, len(cfg.MethodContext))
+		require.Equal(t, true, cfg.EnableBase)
 	})
 
 	t.Run("LoadSidetreePeer", func(t *testing.T) {

--- a/pkg/peer/mocks/protocolversionfactory.gen.go
+++ b/pkg/peer/mocks/protocolversionfactory.gen.go
@@ -4,53 +4,56 @@ package mocks
 import (
 	"sync"
 
-	casApi "github.com/trustbloc/sidetree-core-go/pkg/api/cas"
-	protocolApi "github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	common2 "github.com/trustbloc/sidetree-fabric/pkg/common"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
+	"github.com/trustbloc/sidetree-fabric/pkg/config"
 	"github.com/trustbloc/sidetree-fabric/pkg/context/common"
 )
 
 type ProtocolVersionFactory struct {
-	CreateProtocolVersionStub        func(version string, p protocolApi.Protocol, casClient casApi.Client, opStore common.OperationStore, docType common2.DocumentType) (protocolApi.Version, error)
+	CreateProtocolVersionStub        func(string, protocol.Protocol, cas.Client, common.OperationStore, string, config.Sidetree) (protocol.Version, error)
 	createProtocolVersionMutex       sync.RWMutex
 	createProtocolVersionArgsForCall []struct {
-		version   string
-		p         protocolApi.Protocol
-		casClient casApi.Client
-		opStore   common.OperationStore
-		docType   common2.DocumentType
+		arg1 string
+		arg2 protocol.Protocol
+		arg3 cas.Client
+		arg4 common.OperationStore
+		arg5 string
+		arg6 config.Sidetree
 	}
 	createProtocolVersionReturns struct {
-		result1 protocolApi.Version
+		result1 protocol.Version
 		result2 error
 	}
 	createProtocolVersionReturnsOnCall map[int]struct {
-		result1 protocolApi.Version
+		result1 protocol.Version
 		result2 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ProtocolVersionFactory) CreateProtocolVersion(version string, p protocolApi.Protocol, casClient casApi.Client, opStore common.OperationStore, docType common2.DocumentType) (protocolApi.Version, error) {
+func (fake *ProtocolVersionFactory) CreateProtocolVersion(arg1 string, arg2 protocol.Protocol, arg3 cas.Client, arg4 common.OperationStore, arg5 string, arg6 config.Sidetree) (protocol.Version, error) {
 	fake.createProtocolVersionMutex.Lock()
 	ret, specificReturn := fake.createProtocolVersionReturnsOnCall[len(fake.createProtocolVersionArgsForCall)]
 	fake.createProtocolVersionArgsForCall = append(fake.createProtocolVersionArgsForCall, struct {
-		version   string
-		p         protocolApi.Protocol
-		casClient casApi.Client
-		opStore   common.OperationStore
-		docType   common2.DocumentType
-	}{version, p, casClient, opStore, docType})
-	fake.recordInvocation("CreateProtocolVersion", []interface{}{version, p, casClient, opStore, docType})
+		arg1 string
+		arg2 protocol.Protocol
+		arg3 cas.Client
+		arg4 common.OperationStore
+		arg5 string
+		arg6 config.Sidetree
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("CreateProtocolVersion", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.createProtocolVersionMutex.Unlock()
 	if fake.CreateProtocolVersionStub != nil {
-		return fake.CreateProtocolVersionStub(version, p, casClient, opStore, docType)
+		return fake.CreateProtocolVersionStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.createProtocolVersionReturns.result1, fake.createProtocolVersionReturns.result2
+	fakeReturns := fake.createProtocolVersionReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ProtocolVersionFactory) CreateProtocolVersionCallCount() int {
@@ -59,30 +62,41 @@ func (fake *ProtocolVersionFactory) CreateProtocolVersionCallCount() int {
 	return len(fake.createProtocolVersionArgsForCall)
 }
 
-func (fake *ProtocolVersionFactory) CreateProtocolVersionArgsForCall(i int) (string, protocolApi.Protocol, casApi.Client, common.OperationStore, common2.DocumentType) {
-	fake.createProtocolVersionMutex.RLock()
-	defer fake.createProtocolVersionMutex.RUnlock()
-	return fake.createProtocolVersionArgsForCall[i].version, fake.createProtocolVersionArgsForCall[i].p, fake.createProtocolVersionArgsForCall[i].casClient, fake.createProtocolVersionArgsForCall[i].opStore, fake.createProtocolVersionArgsForCall[i].docType
+func (fake *ProtocolVersionFactory) CreateProtocolVersionCalls(stub func(string, protocol.Protocol, cas.Client, common.OperationStore, string, config.Sidetree) (protocol.Version, error)) {
+	fake.createProtocolVersionMutex.Lock()
+	defer fake.createProtocolVersionMutex.Unlock()
+	fake.CreateProtocolVersionStub = stub
 }
 
-func (fake *ProtocolVersionFactory) CreateProtocolVersionReturns(result1 protocolApi.Version, result2 error) {
+func (fake *ProtocolVersionFactory) CreateProtocolVersionArgsForCall(i int) (string, protocol.Protocol, cas.Client, common.OperationStore, string, config.Sidetree) {
+	fake.createProtocolVersionMutex.RLock()
+	defer fake.createProtocolVersionMutex.RUnlock()
+	argsForCall := fake.createProtocolVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
+}
+
+func (fake *ProtocolVersionFactory) CreateProtocolVersionReturns(result1 protocol.Version, result2 error) {
+	fake.createProtocolVersionMutex.Lock()
+	defer fake.createProtocolVersionMutex.Unlock()
 	fake.CreateProtocolVersionStub = nil
 	fake.createProtocolVersionReturns = struct {
-		result1 protocolApi.Version
+		result1 protocol.Version
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *ProtocolVersionFactory) CreateProtocolVersionReturnsOnCall(i int, result1 protocolApi.Version, result2 error) {
+func (fake *ProtocolVersionFactory) CreateProtocolVersionReturnsOnCall(i int, result1 protocol.Version, result2 error) {
+	fake.createProtocolVersionMutex.Lock()
+	defer fake.createProtocolVersionMutex.Unlock()
 	fake.CreateProtocolVersionStub = nil
 	if fake.createProtocolVersionReturnsOnCall == nil {
 		fake.createProtocolVersionReturnsOnCall = make(map[int]struct {
-			result1 protocolApi.Version
+			result1 protocol.Version
 			result2 error
 		})
 	}
 	fake.createProtocolVersionReturnsOnCall[i] = struct {
-		result1 protocolApi.Version
+		result1 protocol.Version
 		result2 error
 	}{result1, result2}
 }

--- a/pkg/peer/sidetreesvc/context.go
+++ b/pkg/peer/sidetreesvc/context.go
@@ -60,7 +60,7 @@ type blockchainClientProvider interface {
 }
 
 type protocolVersionFactory interface {
-	CreateProtocolVersion(version string, p protocolApi.Protocol, casClient casApi.Client, opStore ctxcommon.OperationStore, docType common.DocumentType) (protocolApi.Version, error)
+	CreateProtocolVersion(version string, p protocolApi.Protocol, casClient casApi.Client, opStore ctxcommon.OperationStore, docType common.DocumentType, sidetreeCfg config.Sidetree) (protocolApi.Version, error)
 }
 
 // ContextProviders defines the providers required by the context
@@ -127,9 +127,14 @@ func newSidetreeContext(channelID, namespace string, cfg config.SidetreeService,
 		return nil, err
 	}
 
+	sidetreeCfg, err := cfg.LoadSidetree(namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	var protocolVersions []protocolApi.Version
 	for version, p := range protocols {
-		pv, err := providers.VersionFactory.CreateProtocolVersion(version, p, casClient, opStore, docType)
+		pv, err := providers.VersionFactory.CreateProtocolVersion(version, p, casClient, opStore, docType, sidetreeCfg)
 		if err != nil {
 			// This may be a case where support for a protocol version has been removed but the protocol is still in the ledger config.
 			// Log an error but continue processing other protocol versions.

--- a/pkg/peer/sidetreesvc/context_test.go
+++ b/pkg/peer/sidetreesvc/context_test.go
@@ -101,6 +101,27 @@ func TestContext(t *testing.T) {
 		require.Nil(t, ctx)
 	})
 
+	t.Run("Sidetree config service error", func(t *testing.T) {
+		errExpected := errors.New("injected sidetree config service error")
+
+		protocolVersions := map[string]protocolApi.Protocol{
+			"0.5": {
+				GenesisTime:        100,
+				MultihashAlgorithm: 18,
+				MaxOperationCount:  100,
+				MaxOperationSize:   1000,
+			},
+		}
+
+		stConfigService := &cfgmocks.SidetreeConfigService{}
+		stConfigService.LoadProtocolsReturns(protocolVersions, nil)
+		stConfigService.LoadSidetreeReturns(config.Sidetree{}, errExpected)
+
+		ctx, err := newContext(channel1, nsCfg, dcasCfg, stConfigService, ctxProviders, &mocks.OperationStoreProvider{}, restCfg, cacheProvider)
+		require.EqualError(t, err, errExpected.Error())
+		require.Nil(t, ctx)
+	})
+
 	t.Run("No protocols -> error", func(t *testing.T) {
 		stConfigService := &cfgmocks.SidetreeConfigService{}
 

--- a/pkg/protocolversion/factoryregistry/factoryregistry.go
+++ b/pkg/protocolversion/factoryregistry/factoryregistry.go
@@ -15,6 +15,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 
 	"github.com/trustbloc/sidetree-fabric/pkg/common"
+	"github.com/trustbloc/sidetree-fabric/pkg/config"
 	ctxcommon "github.com/trustbloc/sidetree-fabric/pkg/context/common"
 	versioncommon "github.com/trustbloc/sidetree-fabric/pkg/protocolversion/common"
 )
@@ -22,7 +23,7 @@ import (
 var logger = flogging.MustGetLogger("sidetree_peer")
 
 type factory interface {
-	Create(version string, p protocol.Protocol, casClient cas.Client, opStore ctxcommon.OperationStore, docType common.DocumentType) (protocol.Version, error)
+	Create(version string, p protocol.Protocol, casClient cas.Client, opStore ctxcommon.OperationStore, docType common.DocumentType, sidetreeCfg config.Sidetree) (protocol.Version, error)
 }
 
 var mutex sync.RWMutex
@@ -40,7 +41,7 @@ func New() *Registry {
 }
 
 // CreateProtocolVersion creates a new protocol version using the given version, protocol and providers
-func (m *Registry) CreateProtocolVersion(version string, p protocol.Protocol, casClient cas.Client, opStore ctxcommon.OperationStore, docType common.DocumentType) (protocol.Version, error) {
+func (m *Registry) CreateProtocolVersion(version string, p protocol.Protocol, casClient cas.Client, opStore ctxcommon.OperationStore, docType common.DocumentType, sidetreeCfg config.Sidetree) (protocol.Version, error) {
 	v, err := m.resolveFactory(version)
 	if err != nil {
 		return nil, err
@@ -48,7 +49,7 @@ func (m *Registry) CreateProtocolVersion(version string, p protocol.Protocol, ca
 
 	logger.Infof("Creating protocol version [%s]", version)
 
-	return v.Create(version, p, casClient, opStore, docType)
+	return v.Create(version, p, casClient, opStore, docType, sidetreeCfg)
 }
 
 // Register registers a protocol factory for a given version

--- a/pkg/protocolversion/factoryregistry/factoryregistry_test.go
+++ b/pkg/protocolversion/factoryregistry/factoryregistry_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package factoryregistry
 
 import (
+	"github.com/trustbloc/sidetree-fabric/pkg/config"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -37,11 +38,11 @@ func TestRegistry(t *testing.T) {
 	opStore := &mocks.OperationStore{}
 	docType := common.DIDDocType
 
-	pv, err := r.CreateProtocolVersion(version, p, casClient, opStore, docType)
+	pv, err := r.CreateProtocolVersion(version, p, casClient, opStore, docType, config.Sidetree{})
 	require.NoError(t, err)
 	require.NotNil(t, pv)
 
-	pv, err = r.CreateProtocolVersion("99", p, casClient, opStore, docType)
+	pv, err = r.CreateProtocolVersion("99", p, casClient, opStore, docType, config.Sidetree{})
 	require.EqualError(t, err, "protocol version factory for version [99] not found")
 	require.Nil(t, pv)
 }

--- a/pkg/protocolversion/factoryregistry/mocks/protocolfactory.gen.go
+++ b/pkg/protocolversion/factoryregistry/mocks/protocolfactory.gen.go
@@ -6,19 +6,20 @@ import (
 
 	"github.com/trustbloc/sidetree-core-go/pkg/api/cas"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
-	common2 "github.com/trustbloc/sidetree-fabric/pkg/common"
-	ctxcommon "github.com/trustbloc/sidetree-fabric/pkg/context/common"
+	"github.com/trustbloc/sidetree-fabric/pkg/config"
+	"github.com/trustbloc/sidetree-fabric/pkg/context/common"
 )
 
 type ProtocolFactory struct {
-	CreateStub        func(version string, p protocol.Protocol, casClient cas.Client, opStore ctxcommon.OperationStore, docType common2.DocumentType) (protocol.Version, error)
+	CreateStub        func(string, protocol.Protocol, cas.Client, common.OperationStore, string, config.Sidetree) (protocol.Version, error)
 	createMutex       sync.RWMutex
 	createArgsForCall []struct {
-		version   string
-		p         protocol.Protocol
-		casClient cas.Client
-		opStore   ctxcommon.OperationStore
-		docType   common2.DocumentType
+		arg1 string
+		arg2 protocol.Protocol
+		arg3 cas.Client
+		arg4 common.OperationStore
+		arg5 string
+		arg6 config.Sidetree
 	}
 	createReturns struct {
 		result1 protocol.Version
@@ -32,25 +33,27 @@ type ProtocolFactory struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *ProtocolFactory) Create(version string, p protocol.Protocol, casClient cas.Client, opStore ctxcommon.OperationStore, docType common2.DocumentType) (protocol.Version, error) {
+func (fake *ProtocolFactory) Create(arg1 string, arg2 protocol.Protocol, arg3 cas.Client, arg4 common.OperationStore, arg5 string, arg6 config.Sidetree) (protocol.Version, error) {
 	fake.createMutex.Lock()
 	ret, specificReturn := fake.createReturnsOnCall[len(fake.createArgsForCall)]
 	fake.createArgsForCall = append(fake.createArgsForCall, struct {
-		version   string
-		p         protocol.Protocol
-		casClient cas.Client
-		opStore   ctxcommon.OperationStore
-		docType   common2.DocumentType
-	}{version, p, casClient, opStore, docType})
-	fake.recordInvocation("Create", []interface{}{version, p, casClient, opStore, docType})
+		arg1 string
+		arg2 protocol.Protocol
+		arg3 cas.Client
+		arg4 common.OperationStore
+		arg5 string
+		arg6 config.Sidetree
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
+	fake.recordInvocation("Create", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.createMutex.Unlock()
 	if fake.CreateStub != nil {
-		return fake.CreateStub(version, p, casClient, opStore, docType)
+		return fake.CreateStub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.createReturns.result1, fake.createReturns.result2
+	fakeReturns := fake.createReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *ProtocolFactory) CreateCallCount() int {
@@ -59,13 +62,22 @@ func (fake *ProtocolFactory) CreateCallCount() int {
 	return len(fake.createArgsForCall)
 }
 
-func (fake *ProtocolFactory) CreateArgsForCall(i int) (string, protocol.Protocol, cas.Client, ctxcommon.OperationStore, common2.DocumentType) {
+func (fake *ProtocolFactory) CreateCalls(stub func(string, protocol.Protocol, cas.Client, common.OperationStore, string, config.Sidetree) (protocol.Version, error)) {
+	fake.createMutex.Lock()
+	defer fake.createMutex.Unlock()
+	fake.CreateStub = stub
+}
+
+func (fake *ProtocolFactory) CreateArgsForCall(i int) (string, protocol.Protocol, cas.Client, common.OperationStore, string, config.Sidetree) {
 	fake.createMutex.RLock()
 	defer fake.createMutex.RUnlock()
-	return fake.createArgsForCall[i].version, fake.createArgsForCall[i].p, fake.createArgsForCall[i].casClient, fake.createArgsForCall[i].opStore, fake.createArgsForCall[i].docType
+	argsForCall := fake.createArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *ProtocolFactory) CreateReturns(result1 protocol.Version, result2 error) {
+	fake.createMutex.Lock()
+	defer fake.createMutex.Unlock()
 	fake.CreateStub = nil
 	fake.createReturns = struct {
 		result1 protocol.Version
@@ -74,6 +86,8 @@ func (fake *ProtocolFactory) CreateReturns(result1 protocol.Version, result2 err
 }
 
 func (fake *ProtocolFactory) CreateReturnsOnCall(i int, result1 protocol.Version, result2 error) {
+	fake.createMutex.Lock()
+	defer fake.createMutex.Unlock()
 	fake.CreateStub = nil
 	if fake.createReturnsOnCall == nil {
 		fake.createReturnsOnCall = make(map[int]struct {

--- a/pkg/protocolversion/versions/v0_1/factory/factory_test.go
+++ b/pkg/protocolversion/versions/v0_1/factory/factory_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/trustbloc/sidetree-core-go/pkg/api/protocol"
 
 	"github.com/trustbloc/sidetree-fabric/pkg/common"
+	"github.com/trustbloc/sidetree-fabric/pkg/config"
 	"github.com/trustbloc/sidetree-fabric/pkg/mocks"
 )
 
@@ -26,19 +27,19 @@ func TestFactory_Create(t *testing.T) {
 	opStore := &mocks.OperationStore{}
 
 	t.Run("DID doc type", func(t *testing.T) {
-		pv, err := f.Create("", p, casClient, opStore, common.DIDDocType)
+		pv, err := f.Create("", p, casClient, opStore, common.DIDDocType, config.Sidetree{})
 		require.NoError(t, err)
 		require.NotNil(t, pv)
 	})
 
 	t.Run("FileIndex doc type", func(t *testing.T) {
-		pv, err := f.Create("", p, casClient, opStore, common.FileIndexType)
+		pv, err := f.Create("", p, casClient, opStore, common.FileIndexType, config.Sidetree{})
 		require.NoError(t, err)
 		require.NotNil(t, pv)
 	})
 
 	t.Run("Invalid doc type", func(t *testing.T) {
-		pv, err := f.Create("", p, casClient, opStore, "invalid")
+		pv, err := f.Create("", p, casClient, opStore, "invalid", config.Sidetree{})
 		require.EqualError(t, err, "unsupported document type: [invalid]")
 		require.Nil(t, pv)
 	})


### PR DESCRIPTION
 Enable the following properties for document transformer:
- method context configuration
- @base property (new)

Closes #480

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>