### PR TITLE
chore: update sidetree-core (reveal value added to requests)

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -771,8 +771,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20201201191333-ef814cdd19db
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20201201191333-ef814cdd19db/go.mod h1:hil7DJWkbNoLezsVWTkGMiXc0KRMpETmU3U3P5G5zDc=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5 h1:dJ/Bt/nj98SRhUlZQc2DV5wRSE/oDcs3gJQRimwNQ3o=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/edge-core v0.1.4
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.5
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f
 	go.uber.org/zap v1.14.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -778,8 +778,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20201201191333-ef814cdd19db
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20201201191333-ef814cdd19db/go.mod h1:hil7DJWkbNoLezsVWTkGMiXc0KRMpETmU3U3P5G5zDc=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5 h1:dJ/Bt/nj98SRhUlZQc2DV5wRSE/oDcs3gJQRimwNQ3o=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/context/protocol/client_test.go
+++ b/pkg/context/protocol/client_test.go
@@ -25,18 +25,18 @@ func TestNew(t *testing.T) {
 func TestClient_Current(t *testing.T) {
 	v1_0 := &coremocks.ProtocolVersion{}
 	v1_0.ProtocolReturns(protocol.Protocol{
-		GenesisTime:        500000,
-		MultihashAlgorithm: 18,
-		MaxOperationSize:   2000,
-		MaxOperationCount:  10000,
+		GenesisTime:         500000,
+		MultihashAlgorithms: []uint{18},
+		MaxOperationSize:    2000,
+		MaxOperationCount:   10000,
 	})
 
 	v0_1 := &coremocks.ProtocolVersion{}
 	v0_1.ProtocolReturns(protocol.Protocol{
-		GenesisTime:        0,
-		MultihashAlgorithm: 18,
-		MaxOperationSize:   500,
-		MaxOperationCount:  100,
+		GenesisTime:         0,
+		MultihashAlgorithms: []uint{18},
+		MaxOperationSize:    500,
+		MaxOperationCount:   100,
 	})
 
 	versions := []protocol.Version{v1_0, v0_1}
@@ -67,19 +67,19 @@ func TestClient_Get(t *testing.T) {
 	v1_0 := &coremocks.ProtocolVersion{}
 	v1_0.VersionReturns("1.0")
 	v1_0.ProtocolReturns(protocol.Protocol{
-		GenesisTime:        500000,
-		MultihashAlgorithm: 18,
-		MaxOperationSize:   2000,
-		MaxOperationCount:  10000,
+		GenesisTime:         500000,
+		MultihashAlgorithms: []uint{18},
+		MaxOperationSize:    2000,
+		MaxOperationCount:   10000,
 	})
 
 	v0_1 := &coremocks.ProtocolVersion{}
 	v0_1.VersionReturns("0.1")
 	v0_1.ProtocolReturns(protocol.Protocol{
-		GenesisTime:        10,
-		MultihashAlgorithm: 18,
-		MaxOperationSize:   500,
-		MaxOperationCount:  100,
+		GenesisTime:         10,
+		MultihashAlgorithms: []uint{18},
+		MaxOperationSize:    500,
+		MaxOperationCount:   100,
 	})
 
 	versions := []protocol.Version{v1_0, v0_1}

--- a/pkg/httpserver/server_test.go
+++ b/pkg/httpserver/server_test.go
@@ -48,7 +48,7 @@ const (
 
 var p = protocol.Protocol{
 	GenesisTime:                 0,
-	MultihashAlgorithm:          sha2_256,
+	MultihashAlgorithms:         []uint{sha2_256},
 	MaxOperationCount:           2,
 	MaxOperationSize:            1024,
 	CompressionAlgorithm:        "GZIP",
@@ -337,12 +337,12 @@ func getCreateRequest() ([]byte, error) {
 		X:   "x",
 	}
 
-	recoveryCommitment, err := commitment.Calculate(recoveryKey, sha2_256)
+	recoveryCommitment, err := commitment.GetCommitment(recoveryKey, sha2_256)
 	if err != nil {
 		return nil, err
 	}
 
-	updateCommitment, err := commitment.Calculate(updateKey, sha2_256)
+	updateCommitment, err := commitment.GetCommitment(updateKey, sha2_256)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/observer/observer_test.go
+++ b/pkg/observer/observer_test.go
@@ -624,7 +624,7 @@ func newMockProtocolVersion() (*coremocks.ProtocolVersion, *coremocks.TxnProcess
 
 	p := protocol.Protocol{
 		GenesisTime:                 0,
-		MultihashAlgorithm:          sha2_256,
+		MultihashAlgorithms:         []uint{sha2_256},
 		MaxOperationCount:           2,
 		MaxOperationSize:            maxOperationByteSize,
 		CompressionAlgorithm:        "GZIP",

--- a/pkg/peer/config/service_test.go
+++ b/pkg/peer/config/service_test.go
@@ -44,8 +44,8 @@ const (
 	didSidetreeCfgJSON               = `{"batchWriterTimeout":"5s"}`
 	didSidetreeCfgJSONWithMethodCtx  = `{"batchWriterTimeout":"5s","methodContext":["ctx1","ctx2"]}`
 	didSidetreeCfgJSONWithBase       = `{"batchWriterTimeout":"5s","enableBase":true}`
-	didSidetreeProtocol_V0_4_CfgJSON = `{"genesisTime":200000,"multihashAlgorithm":18,"maxOperationSize":2000,"maxOperationCount":10}`
-	didSidetreeProtocol_V0_5_CfgJSON = `{"genesisTime":500000,"multihashAlgorithm":18,"maxOperationSize":10000,"maxOperationCount":100}`
+	didSidetreeProtocol_V0_4_CfgJSON = `{"genesisTime":200000,"multihashAlgorithms":[18],"maxOperationSize":2000,"maxOperationCount":10}`
+	didSidetreeProtocol_V0_5_CfgJSON = `{"genesisTime":500000,"multihashAlgorithms":[18],"maxOperationSize":10000,"maxOperationCount":100}`
 	sidetreePeerCfgJson              = `{"Observer":{"Period":"5s"}}`
 	sidetreeHandler1CfgJson          = `{"Namespace":"did:sidetree","BasePath":"/sidetree/0.0.1","Aliases":["did:domain.com","did:alias.com"]}`
 	sidetreeHandler2CfgJson          = `{"Namespace":"file:idx","BasePath":"/file"}`
@@ -106,14 +106,14 @@ func TestNewSidetreeProvider(t *testing.T) {
 		protocol4, ok := protocols[v0_4]
 		require.True(t, ok)
 		require.Equal(t, uint64(200000), protocol4.GenesisTime)
-		require.Equal(t, uint(18), protocol4.MultihashAlgorithm)
+		require.Equal(t, uint(18), protocol4.MultihashAlgorithms[0])
 		require.Equal(t, uint(2000), protocol4.MaxOperationSize)
 		require.Equal(t, uint(10), protocol4.MaxOperationCount)
 
 		protocol5, ok := protocols[v0_5]
 		require.True(t, ok)
 		require.Equal(t, uint64(500000), protocol5.GenesisTime)
-		require.Equal(t, uint(18), protocol5.MultihashAlgorithm)
+		require.Equal(t, uint(18), protocol5.MultihashAlgorithms[0])
 		require.Equal(t, uint(10000), protocol5.MaxOperationSize)
 		require.Equal(t, uint(100), protocol5.MaxOperationCount)
 	})

--- a/pkg/peer/config/sidetreevalidator_test.go
+++ b/pkg/peer/config/sidetreevalidator_test.go
@@ -16,12 +16,11 @@ import (
 const (
 	protocolCfg = `{
 		"genesisTime": 500000,
-		"multihashAlgorithm": 18,
+		"multihashAlgorithms": [18],
 		"maxOperationSize": 2000,
 		"maxOperationCount": 10,
 		"maxOperationHashLength":100,
 		"maxDeltaSize": 1000,
-		"maxProofSize": 500,
 		"maxCasUriLength": 100,
 		"compressionAlgorithm": "GZIP",
 		"maxCoreIndexFileSize": 1000000,
@@ -35,12 +34,11 @@ const (
 
 	protocolInvalidMulithashAlgoCfg = `{
 		"genesisTime": 500000,
-		"multihashAlgorithm": 2777,
+		"multihashAlgorithms": [2777],
 		"maxOperationSize": 2000,
 		"maxOperationCount": 10,
 		"maxOperationHashLength": 100,
 		"maxDeltaSize": 1000,
-		"maxProofSize": 500,
 		"maxCasUriLength": 100,
 		"compressionAlgorithm": "GZIP",
 		"maxCoreIndexFileSize": 1000000,

--- a/pkg/peer/init_test.go
+++ b/pkg/peer/init_test.go
@@ -80,15 +80,15 @@ const (
 
 	didTrustblocNamespace             = "did:bloc:trustbloc.dev"
 	didTrustblocBasePath              = "/trustbloc.dev/identifiers"
-	didTrustblocProtocol_V0_5_CfgJSON = `{"genesisTime":0,"multihashAlgorithm":18,"maxOperationSize":20000,"maxOperationCount":200}`
+	didTrustblocProtocol_V0_5_CfgJSON = `{"genesisTime":0,"multihashAlgorithms":[18],"maxOperationSize":20000,"maxOperationCount":200}`
 	didTrustblocCfgYaml               = `batchWriterTimeout: 1s`
 	didTrustblocCfgUpdateYaml         = `batchWriterTimeout: 5s`
 
 	didSidetreeNamespace             = "did:sidetree"
 	didSidetreeBasePath              = "/document/identifiers"
 	didSidetreeCfgJSON               = `{"batchWriterTimeout":"5s"}`
-	didSidetreeProtocol_V0_4_CfgJSON = `{"genesisTime":0,"multihashAlgorithm":18,"maxOperationSize":2000,"maxOperationCount":10}`
-	didSidetreeProtocol_V0_5_CfgJSON = `{"genesisTime":500000,"multihashAlgorithm":18,"maxOperationSize":10000,"maxOperationCount":100}`
+	didSidetreeProtocol_V0_4_CfgJSON = `{"genesisTime":0,"multihashAlgorithms":[18],"maxOperationSize":2000,"maxOperationCount":10}`
+	didSidetreeProtocol_V0_5_CfgJSON = `{"genesisTime":500000,"multihashAlgorithms":[18],"maxOperationSize":10000,"maxOperationCount":100}`
 )
 
 var (

--- a/pkg/peer/sidetreesvc/channelctrl_test.go
+++ b/pkg/peer/sidetreesvc/channelctrl_test.go
@@ -90,10 +90,10 @@ func TestChannelController_Update(t *testing.T) {
 	}
 
 	p := protocolApi.Protocol{
-		GenesisTime:        100,
-		MultihashAlgorithm: 18,
-		MaxOperationCount:  100,
-		MaxOperationSize:   1000,
+		GenesisTime:         100,
+		MultihashAlgorithms: []uint{18},
+		MaxOperationCount:   100,
+		MaxOperationSize:    1000,
 	}
 
 	protocolVersions := map[string]protocolApi.Protocol{"0.5": p}

--- a/pkg/peer/sidetreesvc/context_test.go
+++ b/pkg/peer/sidetreesvc/context_test.go
@@ -55,10 +55,10 @@ func TestContext(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		protocolVersions := map[string]protocolApi.Protocol{
 			"0.5": {
-				GenesisTime:        100,
-				MultihashAlgorithm: 18,
-				MaxOperationCount:  100,
-				MaxOperationSize:   1000,
+				GenesisTime:         100,
+				MultihashAlgorithms: []uint{18},
+				MaxOperationCount:   100,
+				MaxOperationSize:    1000,
 			},
 		}
 
@@ -83,10 +83,10 @@ func TestContext(t *testing.T) {
 
 		protocolVersions := map[string]protocolApi.Protocol{
 			"0.5": {
-				GenesisTime:        100,
-				MultihashAlgorithm: 18,
-				MaxOperationCount:  100,
-				MaxOperationSize:   1000,
+				GenesisTime:         100,
+				MultihashAlgorithms: []uint{18},
+				MaxOperationCount:   100,
+				MaxOperationSize:    1000,
 			},
 		}
 
@@ -106,10 +106,10 @@ func TestContext(t *testing.T) {
 
 		protocolVersions := map[string]protocolApi.Protocol{
 			"0.5": {
-				GenesisTime:        100,
-				MultihashAlgorithm: 18,
-				MaxOperationCount:  100,
-				MaxOperationSize:   1000,
+				GenesisTime:         100,
+				MultihashAlgorithms: []uint{18},
+				MaxOperationCount:   100,
+				MaxOperationSize:    1000,
 			},
 		}
 

--- a/pkg/peer/sidetreesvc/provider_test.go
+++ b/pkg/peer/sidetreesvc/provider_test.go
@@ -67,10 +67,10 @@ func TestProvider(t *testing.T) {
 	}
 
 	pr := protocolApi.Protocol{
-		GenesisTime:        100,
-		MultihashAlgorithm: 18,
-		MaxOperationCount:  100,
-		MaxOperationSize:   1000,
+		GenesisTime:         100,
+		MultihashAlgorithms: []uint{18},
+		MaxOperationCount:   100,
+		MaxOperationSize:    1000,
 	}
 
 	protocolVersions := map[string]protocolApi.Protocol{"0.5": pr}

--- a/pkg/protocolversion/versions/v0_1/validator/fileidxvalidator_test.go
+++ b/pkg/protocolversion/versions/v0_1/validator/fileidxvalidator_test.go
@@ -12,11 +12,11 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
-
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
+	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
@@ -212,9 +212,15 @@ func getUpdateRequest(patches string) ([]byte, error) {
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(updatePubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	return client.NewUpdateRequest(
 		&client.UpdateRequestInfo{
 			DidSuffix:     "1234",
+			RevealValue:   revealValue,
 			Patches:       []patch.Patch{updatePatch},
 			MultihashCode: sha2_256,
 			UpdateKey:     updatePubKey,

--- a/pkg/protocolversion/versions/v0_1/validator/validator.go
+++ b/pkg/protocolversion/versions/v0_1/validator/validator.go
@@ -15,8 +15,14 @@ import (
 
 // Validate validates the parameters on the given protococol
 func Validate(p *protocol.Protocol) error {
-	if _, err := hashing.GetHashFromMultihash(p.MultihashAlgorithm); err != nil {
-		return errors.WithMessagef(err, "error in Sidetree protocol")
+	if len(p.MultihashAlgorithms) == 0 {
+		return errors.Errorf("field 'MultihashAlgorithms' cannot be empty")
+	}
+
+	for _, alg := range p.MultihashAlgorithms {
+		if _, err := hashing.GetHashFromMultihash(alg); err != nil {
+			return errors.WithMessagef(err, "error in Sidetree protocol for multihash algorithm(%d)", alg)
+		}
 	}
 
 	if p.MaxOperationCount == 0 {
@@ -67,10 +73,6 @@ func verifyBatchSizesV0(p *protocol.Protocol) error {
 
 	if p.MaxDeltaSize == 0 {
 		return errors.Errorf(errMsg, "MaxDeltaSize")
-	}
-
-	if p.MaxProofSize == 0 {
-		return errors.Errorf(errMsg, "MaxProofSize")
 	}
 
 	if p.MaxCasURILength == 0 {

--- a/pkg/protocolversion/versions/v0_1/validator/validator_test.go
+++ b/pkg/protocolversion/versions/v0_1/validator/validator_test.go
@@ -20,13 +20,22 @@ func TestValidator_Validate(t *testing.T) {
 		require.NoError(t, Validate(p))
 	})
 
-	t.Run("Invalid multihash algorithm -> error", func(t *testing.T) {
+	t.Run("Missing multihash algorithms -> error", func(t *testing.T) {
 		protocolInvalidMulithashAlg := getProtocol()
-		protocolInvalidMulithashAlg.MultihashAlgorithm = 2777
+		protocolInvalidMulithashAlg.MultihashAlgorithms = nil
 
 		err := Validate(protocolInvalidMulithashAlg)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "algorithm not supported")
+		require.Contains(t, err.Error(), "field 'MultihashAlgorithms' cannot be empty")
+	})
+
+	t.Run("Invalid multihash algorithm -> error", func(t *testing.T) {
+		protocolInvalidMulithashAlg := getProtocol()
+		protocolInvalidMulithashAlg.MultihashAlgorithms = []uint{2777}
+
+		err := Validate(protocolInvalidMulithashAlg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "error in Sidetree protocol for multihash algorithm(2777): algorithm not supported")
 	})
 
 	t.Run("Invalid MaxOperationCount -> error", func(t *testing.T) {
@@ -45,15 +54,6 @@ func TestValidator_Validate(t *testing.T) {
 		err := Validate(protocolInvalidMaxOperationSize)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "field 'MaxOperationSize' must contain a value greater than 0")
-	})
-
-	t.Run("Invalid MaxProofSize -> error", func(t *testing.T) {
-		protocolInvalidMaxProofSize := getProtocol()
-		protocolInvalidMaxProofSize.MaxProofSize = 0
-
-		err := Validate(protocolInvalidMaxProofSize)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "field 'MaxProofSize' must contain a value greater than 0")
 	})
 
 	t.Run("Invalid MaxDeltaSize -> error", func(t *testing.T) {
@@ -159,11 +159,10 @@ func TestValidator_Validate(t *testing.T) {
 func getProtocol() *protocol.Protocol {
 	return &protocol.Protocol{
 		GenesisTime:                 500000,
-		MultihashAlgorithm:          18,
+		MultihashAlgorithms:         []uint{18},
 		MaxOperationSize:            2000,
 		MaxOperationHashLength:      100,
 		MaxDeltaSize:                1000,
-		MaxProofSize:                500,
 		MaxCasURILength:             100,
 		MaxOperationCount:           10,
 		CompressionAlgorithm:        "GZIP",

--- a/test/bddtests/did_sidetree_steps.go
+++ b/test/bddtests/did_sidetree_steps.go
@@ -443,7 +443,7 @@ func getCommitment(key *ecdsa.PublicKey) (string, error) {
 		return "", err
 	}
 
-	return commitment.Calculate(pubKey, sha2_256)
+	return commitment.GetCommitment(pubKey, sha2_256)
 }
 
 func (d *DIDSideSteps) getRecoverRequest(doc []byte, uniqueSuffix string) ([]byte, error) {
@@ -463,8 +463,13 @@ func (d *DIDSideSteps) getRecoverRequest(doc []byte, uniqueSuffix string) ([]byt
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(recoveryPubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
 	recoverRequest, err := client.NewRecoverRequest(&client.RecoverRequestInfo{
 		DidSuffix:          uniqueSuffix,
+		RevealValue:        revealValue,
 		OpaqueDocument:     string(doc),
 		RecoveryKey:        recoveryPubKey,
 		RecoveryCommitment: recoveryCommitment,
@@ -491,8 +496,14 @@ func (d *DIDSideSteps) getDeactivateRequest(did string) ([]byte, error) {
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(recoveryPubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	return client.NewDeactivateRequest(&client.DeactivateRequestInfo{
 		DidSuffix:   did,
+		RevealValue: revealValue,
 		RecoveryKey: recoveryPubKey,
 		Signer:      ecsigner.New(d.recoveryKey, "ES256", ""),
 	})
@@ -510,8 +521,14 @@ func (d *DIDSideSteps) getUpdateRequest(did string, updatePatch patch.Patch) ([]
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(updatePubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := client.NewUpdateRequest(&client.UpdateRequestInfo{
 		DidSuffix:        did,
+		RevealValue:      revealValue,
 		UpdateCommitment: updateCommitment,
 		UpdateKey:        updatePubKey,
 		Patches:          []patch.Patch{updatePatch},

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -207,11 +207,10 @@ Feature:
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/version?time=50"
     And the JSON path "version" of the response equals "0.1.1"
     And the JSON path "genesisTime" of the numeric response equals "20"
-    And the JSON path "multihashAlgorithm" of the numeric response equals "18"
+    And the JSON path "multihashAlgorithms" of the array response is not empty
     And the JSON path "maxOperationCount" of the numeric response equals "30"
     And the JSON path "maxOperationSize" of the numeric response equals "2400"
     And the JSON path "maxDeltaSize" of the numeric response equals "1700"
-    And the JSON path "maxProofSize" of the numeric response equals "600"
     And the JSON path "maxOperationHashLength" of the numeric response equals "100"
     And the JSON path "maxCasUriLength" of the numeric response equals "100"
     And the JSON path "maxCoreIndexFileSize" of the numeric response equals "1000000"
@@ -227,11 +226,10 @@ Feature:
     When an HTTP GET is sent to "https://localhost:48326/sidetree/0.0.1/version?time=2000"
     And the JSON path "version" of the response equals "0.1.2"
     And the JSON path "genesisTime" of the numeric response equals "1000"
-    And the JSON path "multihashAlgorithm" of the numeric response equals "18"
+    And the JSON path "multihashAlgorithms" of the array response is not empty
     And the JSON path "maxOperationCount" of the numeric response equals "5000"
     And the JSON path "maxOperationSize" of the numeric response equals "2500"
     And the JSON path "maxDeltaSize" of the numeric response equals "1700"
-    And the JSON path "maxProofSize" of the numeric response equals "700"
     And the JSON path "maxOperationHashLength" of the numeric response equals "100"
     And the JSON path "maxCasUriLength" of the numeric response equals "100"
     And the JSON path "maxCoreIndexFileSize" of the numeric response equals "1000000"
@@ -248,7 +246,7 @@ Feature:
     # We can't check for actual version because we don't know how many blocks have been created
     # by the tests so far so we don't know which protocol is current
     And the JSON path "version" of the response is not empty
-    And the JSON path "multihashAlgorithm" of the numeric response equals "18"
+    And the JSON path "multihashAlgorithms" of the array response is not empty
     And the JSON path "compressionAlgorithm" of the response equals "GZIP"
     And the JSON path "signatureAlgorithms" of the array response is not empty
     And the JSON path "keyAlgorithms" of the array response is not empty

--- a/test/bddtests/features/file-handler.feature
+++ b/test/bddtests/features/file-handler.feature
@@ -158,11 +158,10 @@ Feature:
     When an HTTP GET is sent to "https://localhost:48326/file/version?time=50"
     And the JSON path "version" of the response equals "0.1.1"
     And the JSON path "genesisTime" of the numeric response equals "20"
-    And the JSON path "multihashAlgorithm" of the numeric response equals "18"
+    And the JSON path "multihashAlgorithms" of the array response is not empty
     And the JSON path "maxOperationCount" of the numeric response equals "30"
     And the JSON path "maxOperationSize" of the numeric response equals "2400"
     And the JSON path "maxDeltaSize" of the numeric response equals "1700"
-    And the JSON path "maxProofSize" of the numeric response equals "600"
     And the JSON path "maxOperationHashLength" of the numeric response equals "100"
     And the JSON path "maxCasUriLength" of the numeric response equals "100"
     And the JSON path "maxCoreIndexFileSize" of the numeric response equals "1000000"

--- a/test/bddtests/filehandler_steps.go
+++ b/test/bddtests/filehandler_steps.go
@@ -20,13 +20,14 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/trustbloc/fabric-peer-test-common/bddtests"
+	"github.com/trustbloc/sidetree-core-go/pkg/commitment"
 	"github.com/trustbloc/sidetree-core-go/pkg/document"
 	"github.com/trustbloc/sidetree-core-go/pkg/docutil"
 	"github.com/trustbloc/sidetree-core-go/pkg/jws"
 	"github.com/trustbloc/sidetree-core-go/pkg/patch"
-	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/ecsigner"
 	"github.com/trustbloc/sidetree-core-go/pkg/util/pubkey"
+	"github.com/trustbloc/sidetree-core-go/pkg/versions/0_1/client"
 )
 
 // FileHandlerSteps
@@ -276,8 +277,14 @@ func (d *FileHandlerSteps) getUpdateRequest(uniqueSuffix string, jsonPatch strin
 		return nil, err
 	}
 
+	revealValue, err := commitment.GetRevealValue(updatePubKey, sha2_256)
+	if err != nil {
+		return nil, err
+	}
+
 	req, err := client.NewUpdateRequest(&client.UpdateRequestInfo{
 		DidSuffix:        uniqueSuffix,
+		RevealValue:      revealValue,
 		UpdateCommitment: updateCommitment,
 		UpdateKey:        updatePubKey,
 		Patches:          []patch.Patch{updatePatch},

--- a/test/bddtests/fixtures/config/client/protocol.json
+++ b/test/bddtests/fixtures/config/client/protocol.json
@@ -1,12 +1,11 @@
 {
   "1.0": {
     "genesisTime": 1,
-    "multihashAlgorithm": 18,
+    "multihashAlgorithms": [18],
     "maxOperationSize": 2000,
     "maxOperationCount": 10,
     "maxOperationHashLength": 100,
     "maxDeltaSize": 1000,
-    "maxProofSize": 500,
     "maxCasUriLength": 100,
     "compressionAlgorithm": "GZIP",
     "maxCoreIndexFileSize": 1000000,

--- a/test/bddtests/fixtures/config/fabric/invalid-hash-algorithm.json
+++ b/test/bddtests/fixtures/config/fabric/invalid-hash-algorithm.json
@@ -1,11 +1,10 @@
 {
   "genesisTime": 500000,
-  "multihashAlgorithm": 777,
+  "multihashAlgorithms": [777],
   "maxOperationSize": 2000,
   "maxOperationCount": 10,
   "maxOperationHashLength": 100,
   "maxDeltaSize": 1000,
-  "maxProofSize": 500,
   "maxCasUriLength": 100,
   "compressionAlgorithm": "GZIP",
   "maxCoreIndexFileSize": 1000000,

--- a/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1.json
+++ b/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1.json
@@ -1,10 +1,9 @@
 {
   "genesisTime": 1,
-  "multihashAlgorithm": 18,
+  "multihashAlgorithms": [18],
   "maxOperationCount": 10,
   "maxOperationSize": 2500,
   "maxDeltaSize": 1700,
-  "maxProofSize": 700,
   "maxCasUriLength": 100,
   "maxOperationHashLength": 100,
   "compressionAlgorithm": "GZIP",

--- a/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1_1.json
+++ b/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1_1.json
@@ -1,10 +1,9 @@
 {
   "genesisTime": 20,
-  "multihashAlgorithm": 18,
+  "multihashAlgorithms": [18],
   "maxOperationCount": 30,
   "maxOperationSize": 2400,
   "maxDeltaSize": 1700,
-  "maxProofSize": 600,
   "maxCasUriLength": 100,
   "maxOperationHashLength": 100,
   "compressionAlgorithm": "GZIP",

--- a/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1_2.json
+++ b/test/bddtests/fixtures/config/fabric/sidetree-protocol-v0_1_2.json
@@ -1,10 +1,9 @@
 {
   "genesisTime": 1000,
-  "multihashAlgorithm": 18,
+  "multihashAlgorithms": [18],
   "maxOperationCount": 5000,
   "maxOperationSize": 2500,
   "maxDeltaSize": 1700,
-  "maxProofSize": 700,
   "maxCasUriLength": 100,
   "maxOperationHashLength": 100,
   "compressionAlgorithm": "GZIP",

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/trustbloc/fabric-peer-test-common v0.1.5
-	github.com/trustbloc/sidetree-core-go v0.1.5
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.5

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -313,8 +313,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.5 h1:45pztjyFZhRujUIuNg0X4Uq+f
 github.com/trustbloc/fabric-peer-test-common v0.1.5/go.mod h1:+31f4Ca6QzxBqJm5XCAAyc3NkCTqpKa+zgLBpJB5tco=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5 h1:dJ/Bt/nj98SRhUlZQc2DV5wRSE/oDcs3gJQRimwNQ3o=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.5 h1:a4DLyNRHRYfbsLC5Q5SWHP1QBGdaG2UDq9ACspqfa38=
-github.com/trustbloc/sidetree-core-go v0.1.5/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f h1:PHySA3TTpo8xChoP3XlTlrs2wHjkoX6K8A3mbdjVvrs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20201217192009-0d2b4436912f/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=


### PR DESCRIPTION
Complete SIP-1:
- add reveal value in update, reveal, deactivate operations
- support multiple multi-hashing algorithms in protocol
- remove max proof size protocol parameter

Also, added REST API check to fail create if applying patches results in an empty document (due to an error or invalid usage)

Closes #493

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>