### PR TITLE
chore: update sidetree-core: anchor times/origin, deactivate

### DIFF
--- a/cmd/peer/go.sum
+++ b/cmd/peer/go.sum
@@ -771,8 +771,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20210210135812-c5ded8c92cd6
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20210210135812-c5ded8c92cd6/go.mod h1:82CL0ugbO85dLqMTikt69dxwLEVVps200QQ6jO+JTWU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5 h1:dJ/Bt/nj98SRhUlZQc2DV5wRSE/oDcs3gJQRimwNQ3o=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d h1:mOqH952Z36QrL+UqM1E/KT2m9AmF9n1y/8TDTJ7Ff9I=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886 h1:0j2yds0mD6jpTsozEXC8q8vOv/6COXQGR4BgbVuEuF4=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285
 	github.com/trustbloc/edge-core v0.1.4
 	github.com/trustbloc/fabric-peer-ext v0.0.0
-	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886
 	go.uber.org/zap v1.14.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -778,8 +778,8 @@ github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20210210135812-c5ded8c92cd6
 github.com/trustbloc/fabric-peer-ext/mod/peer v0.0.0-20210210135812-c5ded8c92cd6/go.mod h1:82CL0ugbO85dLqMTikt69dxwLEVVps200QQ6jO+JTWU=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5 h1:dJ/Bt/nj98SRhUlZQc2DV5wRSE/oDcs3gJQRimwNQ3o=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d h1:mOqH952Z36QrL+UqM1E/KT2m9AmF9n1y/8TDTJ7Ff9I=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886 h1:0j2yds0mD6jpTsozEXC8q8vOv/6COXQGR4BgbVuEuF4=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.1/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v1.18.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=

--- a/pkg/context/blockchain/client.go
+++ b/pkg/context/blockchain/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pkg/errors"
 	txnapi "github.com/trustbloc/fabric-peer-ext/pkg/txn/api"
+	"github.com/trustbloc/sidetree-core-go/pkg/api/operation"
 	"github.com/trustbloc/sidetree-core-go/pkg/api/txn"
 	"github.com/trustbloc/sidetree-fabric/pkg/observer/common"
 
@@ -44,7 +45,7 @@ func New(channelID, chaincodeName, namespace string, txnProvider txnServiceProvi
 }
 
 // WriteAnchor writes anchor string to blockchain
-func (c *Client) WriteAnchor(anchor string, protocolGenesisTime uint64) error {
+func (c *Client) WriteAnchor(anchor string, _ []*operation.Reference, protocolGenesisTime uint64) error {
 	txnService, err := c.txnProvider.ForChannel(c.channelID)
 	if err != nil {
 		return err

--- a/pkg/context/blockchain/client_test.go
+++ b/pkg/context/blockchain/client_test.go
@@ -35,7 +35,7 @@ func TestGetClientError(t *testing.T) {
 	c := New(chID, ccName, namespace, txnProvider)
 	require.NotNil(t, c)
 
-	err := c.WriteAnchor("anchor", 100)
+	err := c.WriteAnchor("anchor", nil,100)
 	require.EqualError(t, err, testErr.Error())
 }
 
@@ -46,7 +46,7 @@ func TestWriteAnchor(t *testing.T) {
 
 	c := New(chID, ccName, namespace, txnProvider)
 
-	err := c.WriteAnchor("anchor", 100)
+	err := c.WriteAnchor("anchor", nil, 100)
 	require.Nil(t, err)
 }
 
@@ -61,7 +61,7 @@ func TestWriteAnchorError(t *testing.T) {
 	txnProvider.ForChannelReturns(txnService, nil)
 	bc := New(chID, ccName, namespace, txnProvider)
 
-	err := bc.WriteAnchor("anchor", 100)
+	err := bc.WriteAnchor("anchor", nil, 100)
 	require.NotNil(t, err)
 	require.Contains(t, err.Error(), testErr.Error())
 }

--- a/pkg/context/context.go
+++ b/pkg/context/context.go
@@ -25,12 +25,12 @@ import (
 
 // SidetreeContext implements 'Fabric' version of Sidetree node context
 type SidetreeContext struct {
-	channelID        string
-	namespace        string
-	protocolClient   protocolApi.Client
-	casClient        casApi.Client
-	blockchainClient batch.BlockchainClient
-	opQueue          cutter.OperationQueue
+	channelID      string
+	namespace      string
+	protocolClient protocolApi.Client
+	casClient      casApi.Client
+	anchorWriter   batch.AnchorWriter
+	opQueue        cutter.OperationQueue
 }
 
 type txnServiceProvider interface {
@@ -80,12 +80,12 @@ func New(
 	}
 
 	return &SidetreeContext{
-		channelID:        channelID,
-		namespace:        namespace,
-		protocolClient:   protocol.New(protocolVersions, providers.LedgerProvider.GetLedger(channelID)),
-		casClient:        casClient,
-		blockchainClient: blockchain.New(channelID, dcasCfg.ChaincodeName, namespace, providers.TxnProvider),
-		opQueue:          opQueue,
+		channelID:      channelID,
+		namespace:      namespace,
+		protocolClient: protocol.New(protocolVersions, providers.LedgerProvider.GetLedger(channelID)),
+		casClient:      casClient,
+		anchorWriter:   blockchain.New(channelID, dcasCfg.ChaincodeName, namespace, providers.TxnProvider),
+		opQueue:        opQueue,
 	}, nil
 }
 
@@ -99,9 +99,9 @@ func (m *SidetreeContext) Protocol() protocolApi.Client {
 	return m.protocolClient
 }
 
-// Blockchain returns blockchain client
-func (m *SidetreeContext) Blockchain() batch.BlockchainClient {
-	return m.blockchainClient
+// Anchor returns anchor writer
+func (m *SidetreeContext) Anchor() batch.AnchorWriter {
+	return m.anchorWriter
 }
 
 // CAS returns content addressable storage client

--- a/pkg/context/context_test.go
+++ b/pkg/context/context_test.go
@@ -69,7 +69,7 @@ func TestNew(t *testing.T) {
 
 	require.NotNil(t, sctx.Protocol())
 	require.NotNil(t, sctx.CAS())
-	require.NotNil(t, sctx.Blockchain())
+	require.NotNil(t, sctx.Anchor())
 	require.NotEmpty(t, sctx.Namespace())
 	require.NotNil(t, sctx.OperationQueue())
 }

--- a/pkg/mocks/operationhandler.gen.go
+++ b/pkg/mocks/operationhandler.gen.go
@@ -9,24 +9,26 @@ import (
 )
 
 type OperationHandler struct {
-	PrepareTxnFilesStub        func([]*operation.QueuedOperation) (string, error)
+	PrepareTxnFilesStub        func([]*operation.QueuedOperation) (string, []*operation.Reference, error)
 	prepareTxnFilesMutex       sync.RWMutex
 	prepareTxnFilesArgsForCall []struct {
 		arg1 []*operation.QueuedOperation
 	}
 	prepareTxnFilesReturns struct {
 		result1 string
-		result2 error
+		result2 []*operation.Reference
+		result3 error
 	}
 	prepareTxnFilesReturnsOnCall map[int]struct {
 		result1 string
-		result2 error
+		result2 []*operation.Reference
+		result3 error
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *OperationHandler) PrepareTxnFiles(arg1 []*operation.QueuedOperation) (string, error) {
+func (fake *OperationHandler) PrepareTxnFiles(arg1 []*operation.QueuedOperation) (string, []*operation.Reference, error) {
 	var arg1Copy []*operation.QueuedOperation
 	if arg1 != nil {
 		arg1Copy = make([]*operation.QueuedOperation, len(arg1))
@@ -43,10 +45,10 @@ func (fake *OperationHandler) PrepareTxnFiles(arg1 []*operation.QueuedOperation)
 		return fake.PrepareTxnFilesStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
 	fakeReturns := fake.prepareTxnFilesReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *OperationHandler) PrepareTxnFilesCallCount() int {
@@ -55,7 +57,7 @@ func (fake *OperationHandler) PrepareTxnFilesCallCount() int {
 	return len(fake.prepareTxnFilesArgsForCall)
 }
 
-func (fake *OperationHandler) PrepareTxnFilesCalls(stub func([]*operation.QueuedOperation) (string, error)) {
+func (fake *OperationHandler) PrepareTxnFilesCalls(stub func([]*operation.QueuedOperation) (string, []*operation.Reference, error)) {
 	fake.prepareTxnFilesMutex.Lock()
 	defer fake.prepareTxnFilesMutex.Unlock()
 	fake.PrepareTxnFilesStub = stub
@@ -68,30 +70,33 @@ func (fake *OperationHandler) PrepareTxnFilesArgsForCall(i int) []*operation.Que
 	return argsForCall.arg1
 }
 
-func (fake *OperationHandler) PrepareTxnFilesReturns(result1 string, result2 error) {
+func (fake *OperationHandler) PrepareTxnFilesReturns(result1 string, result2 []*operation.Reference, result3 error) {
 	fake.prepareTxnFilesMutex.Lock()
 	defer fake.prepareTxnFilesMutex.Unlock()
 	fake.PrepareTxnFilesStub = nil
 	fake.prepareTxnFilesReturns = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
+		result2 []*operation.Reference
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *OperationHandler) PrepareTxnFilesReturnsOnCall(i int, result1 string, result2 error) {
+func (fake *OperationHandler) PrepareTxnFilesReturnsOnCall(i int, result1 string, result2 []*operation.Reference, result3 error) {
 	fake.prepareTxnFilesMutex.Lock()
 	defer fake.prepareTxnFilesMutex.Unlock()
 	fake.PrepareTxnFilesStub = nil
 	if fake.prepareTxnFilesReturnsOnCall == nil {
 		fake.prepareTxnFilesReturnsOnCall = make(map[int]struct {
 			result1 string
-			result2 error
+			result2 []*operation.Reference
+			result3 error
 		})
 	}
 	fake.prepareTxnFilesReturnsOnCall[i] = struct {
 		result1 string
-		result2 error
-	}{result1, result2}
+		result2 []*operation.Reference
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *OperationHandler) Invocations() map[string][][]interface{} {

--- a/pkg/peer/mocks/batchcontext.gen.go
+++ b/pkg/peer/mocks/batchcontext.gen.go
@@ -19,14 +19,14 @@ type BatchContext struct {
 	protocolReturnsOnCall map[int]struct {
 		result1 protocol.Client
 	}
-	BlockchainStub        func() batch.BlockchainClient
+	BlockchainStub        func() batch.AnchorWriter
 	blockchainMutex       sync.RWMutex
 	blockchainArgsForCall []struct{}
 	blockchainReturns     struct {
-		result1 batch.BlockchainClient
+		result1 batch.AnchorWriter
 	}
 	blockchainReturnsOnCall map[int]struct {
-		result1 batch.BlockchainClient
+		result1 batch.AnchorWriter
 	}
 	OperationQueueStub        func() cutter.OperationQueue
 	operationQueueMutex       sync.RWMutex
@@ -81,11 +81,11 @@ func (fake *BatchContext) ProtocolReturnsOnCall(i int, result1 protocol.Client) 
 	}{result1}
 }
 
-func (fake *BatchContext) Blockchain() batch.BlockchainClient {
+func (fake *BatchContext) Anchor() batch.AnchorWriter {
 	fake.blockchainMutex.Lock()
 	ret, specificReturn := fake.blockchainReturnsOnCall[len(fake.blockchainArgsForCall)]
 	fake.blockchainArgsForCall = append(fake.blockchainArgsForCall, struct{}{})
-	fake.recordInvocation("Blockchain", []interface{}{})
+	fake.recordInvocation("Anchor", []interface{}{})
 	fake.blockchainMutex.Unlock()
 	if fake.BlockchainStub != nil {
 		return fake.BlockchainStub()
@@ -96,28 +96,28 @@ func (fake *BatchContext) Blockchain() batch.BlockchainClient {
 	return fake.blockchainReturns.result1
 }
 
-func (fake *BatchContext) BlockchainCallCount() int {
+func (fake *BatchContext) AnchorCallCount() int {
 	fake.blockchainMutex.RLock()
 	defer fake.blockchainMutex.RUnlock()
 	return len(fake.blockchainArgsForCall)
 }
 
-func (fake *BatchContext) BlockchainReturns(result1 batch.BlockchainClient) {
+func (fake *BatchContext) AnchorReturns(result1 batch.AnchorWriter) {
 	fake.BlockchainStub = nil
 	fake.blockchainReturns = struct {
-		result1 batch.BlockchainClient
+		result1 batch.AnchorWriter
 	}{result1}
 }
 
-func (fake *BatchContext) BlockchainReturnsOnCall(i int, result1 batch.BlockchainClient) {
+func (fake *BatchContext) AnchorReturnsOnCall(i int, result1 batch.AnchorWriter) {
 	fake.BlockchainStub = nil
 	if fake.blockchainReturnsOnCall == nil {
 		fake.blockchainReturnsOnCall = make(map[int]struct {
-			result1 batch.BlockchainClient
+			result1 batch.AnchorWriter
 		})
 	}
 	fake.blockchainReturnsOnCall[i] = struct {
-		result1 batch.BlockchainClient
+		result1 batch.AnchorWriter
 	}{result1}
 }
 

--- a/test/bddtests/features/did-sidetree.feature
+++ b/test/bddtests/features/did-sidetree.feature
@@ -118,7 +118,7 @@ Feature:
     And we wait 10 seconds
 
     When client sends request to "https://localhost:48426/sidetree/0.0.1/identifiers" to resolve DID document
-    Then check error response contains "deactivated"
+    Then check success response contains "deactivated"
 
   @create_recover_did_doc
   Scenario: create and recover did doc

--- a/test/bddtests/go.mod
+++ b/test/bddtests/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/viper v1.4.0
 	github.com/trustbloc/fabric-peer-test-common v0.1.5
-	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d
+	github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886
 )
 
 replace github.com/hyperledger/fabric-protos-go => github.com/trustbloc/fabric-protos-go-ext v0.1.5

--- a/test/bddtests/go.sum
+++ b/test/bddtests/go.sum
@@ -313,8 +313,8 @@ github.com/trustbloc/fabric-peer-test-common v0.1.5 h1:45pztjyFZhRujUIuNg0X4Uq+f
 github.com/trustbloc/fabric-peer-test-common v0.1.5/go.mod h1:+31f4Ca6QzxBqJm5XCAAyc3NkCTqpKa+zgLBpJB5tco=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5 h1:dJ/Bt/nj98SRhUlZQc2DV5wRSE/oDcs3gJQRimwNQ3o=
 github.com/trustbloc/fabric-protos-go-ext v0.1.5/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d h1:mOqH952Z36QrL+UqM1E/KT2m9AmF9n1y/8TDTJ7Ff9I=
-github.com/trustbloc/sidetree-core-go v0.1.6-0.20210115144846-cf582cfe537d/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886 h1:0j2yds0mD6jpTsozEXC8q8vOv/6COXQGR4BgbVuEuF4=
+github.com/trustbloc/sidetree-core-go v0.1.6-0.20210223184536-814c6b81a886/go.mod h1:prRWqxBavkSxgKtPmUriSxCemrvl47yStMbW4jMFuRs=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasttemplate v1.0.1/go.mod h1:UQGH1tvbgY+Nz5t2n7tXsz52dQxojPUpymEIMZ47gx8=


### PR DESCRIPTION
Included:
- deactivate no longer returns 410
- anchor origin
- anchor times (from/until) along with new optional protocol parameter

Closes #503

Signed-off-by: Sandra Vrtikapa <sandra.vrtikapa@securekey.com>